### PR TITLE
Issue/accessibility

### DIFF
--- a/src/atari.coffee
+++ b/src/atari.coffee
@@ -26,6 +26,8 @@ Namespace("Flashcards").Atari =
 		$('#icon-restore').append($($('#t-icon').html()).clone().addClass('restore-table'))
 		$('#icon-rotate').append($($('#t-icon').html()).clone().addClass('rotate-table'))
 		$('#icon-shuffle').append($($('#t-icon').html()).clone().addClass('shuffle-table'))
+		$('#icon-remove')[0].innerText = ""
+		$('#icon-remove').append($($('#t-icon').html()).clone().addClass('discard-table'))
 
 	initializeSounds : ->
 		@Sound.saw0 = T("saw", {freq:110, mul:0.1})

--- a/src/atari.scss
+++ b/src/atari.scss
@@ -105,6 +105,10 @@
 			}
 		}
 		.restore-table {
+			position: absolute;
+			top: 0;
+			left: 0;
+
 			tr {
 				&.tr1 { td:nth-child(3), td:nth-child(4), td:nth-child(5) { background-color : #FFF; } }
 				&.tr2 { td:nth-child(2), td:nth-child(3), td:nth-child(6) { background-color : #FFF; } }

--- a/src/atari.scss
+++ b/src/atari.scss
@@ -92,6 +92,7 @@
 	.icon {
 		background-color : rgba(0,0,0,0) !important;
 		border-radius    : 0 !important;
+		bottom: 50px;
 		&:before { content : "" !important; }
 		table {
 			z-index : -10;

--- a/src/atari.scss
+++ b/src/atari.scss
@@ -1,3 +1,5 @@
+$a : #FFF;
+
 .atari {
 	#fake-loading-screen {
 		display          : block;
@@ -62,16 +64,16 @@
 			}
 			&.left {
 				tr {
-					&.tr1, &.tr5 { td:nth-child(3) { background-color : #FFF; } }
-					&.tr2, &.tr4 { td:nth-child(2) { background-color : #FFF; } }
-					&.tr3        { td              { background-color : #FFF; } }
+					&.tr1, &.tr5 { td:nth-child(3) { background-color : $a; } }
+					&.tr2, &.tr4 { td:nth-child(2) { background-color : $a; } }
+					&.tr3        { td              { background-color : $a; } }
 				}
 			}
 			&.right {
 				tr {
-					&.tr1, &.tr5 { td:nth-child(3) { background-color : #FFF; } }
-					&.tr2, &.tr4 { td:nth-child(4) { background-color : #FFF; } }
-					&.tr3        { td              { background-color : #FFF; } }
+					&.tr1, &.tr5 { td:nth-child(3) { background-color : $a; } }
+					&.tr2, &.tr4 { td:nth-child(4) { background-color : $a; } }
+					&.tr3        { td              { background-color : $a; } }
 				}
 			}
 		}
@@ -87,7 +89,6 @@
 			        transition-timing-function : steps(8, end) !important;
 			transition-duration : 500ms !important;
 		}
-		.remove-button { transition : none !important; }
 	}
 	.icon {
 		background-color : rgba(0,0,0,0) !important;
@@ -111,34 +112,43 @@
 			left: 0;
 
 			tr {
-				&.tr1 { td:nth-child(3), td:nth-child(4), td:nth-child(5) { background-color : #FFF; } }
-				&.tr2 { td:nth-child(2), td:nth-child(3), td:nth-child(6) { background-color : #FFF; } }
-				&.tr3 { td:nth-child(0), td:nth-child(1), td:nth-child(0), td:nth-child(5), td:nth-child(6), td:nth-child(7) { background-color : #FFF; } }
-				&.tr4 { td:nth-child(1), td:nth-child(6) { background-color : #FFF; } }
-				&.tr5 { td:nth-child(1) { background-color : #FFF; } }
-				&.tr6 { td:nth-child(2), td:nth-child(7) { background-color : #FFF; } }
-				&.tr7 { td:nth-child(3), td:nth-child(4), td:nth-child(5), td:nth-child(6) { background-color : #FFF; } }
+				&.tr1 { td:nth-child(3), td:nth-child(4), td:nth-child(5) { background-color : $a; } }
+				&.tr2 { td:nth-child(2), td:nth-child(3), td:nth-child(6) { background-color : $a; } }
+				&.tr3 { td:nth-child(0), td:nth-child(1), td:nth-child(0), td:nth-child(5), td:nth-child(6), td:nth-child(7) { background-color : $a; } }
+				&.tr4 { td:nth-child(1), td:nth-child(6) { background-color : $a; } }
+				&.tr5 { td:nth-child(1) { background-color : $a; } }
+				&.tr6 { td:nth-child(2), td:nth-child(7) { background-color : $a; } }
+				&.tr7 { td:nth-child(3), td:nth-child(4), td:nth-child(5), td:nth-child(6) { background-color : $a; } }
 			}
 		}
 		.rotate-table {
 			tr {
-				&.tr1 { td:nth-child(4), td:nth-child(5), td:nth-child(6) { background-color: #FFF; } }
-				&.tr2 { td:nth-child(3), td:nth-child(7) { background-color : #FFF; } }
-				&.tr3 { td:nth-child(1), td:nth-child(2), td:nth-child(3), td:nth-child(4) { background-color : #FFF; } }
-				&.tr4 { td:nth-child(1), td:nth-child(2), td:nth-child(3), td:nth-child(4), td:nth-child(6), td:nth-child(7) { background-color : #FFF; } }
-				&.tr5 { td:nth-child(1), td:nth-child(2), td:nth-child(3), td:nth-child(4), td:nth-child(6), td:nth-child(7) { background-color : #FFF; } }
+				&.tr1 { td:nth-child(4), td:nth-child(5), td:nth-child(6) { background-color: $a; } }
+				&.tr2 { td:nth-child(3), td:nth-child(7) { background-color : $a; } }
+				&.tr3 { td:nth-child(1), td:nth-child(2), td:nth-child(3), td:nth-child(4) { background-color : $a; } }
+				&.tr4 { td:nth-child(1), td:nth-child(2), td:nth-child(3), td:nth-child(4), td:nth-child(6), td:nth-child(7) { background-color : $a; } }
+				&.tr5 { td:nth-child(1), td:nth-child(2), td:nth-child(3), td:nth-child(4), td:nth-child(6), td:nth-child(7) { background-color : $a; } }
 			}
 		}
 		.shuffle-table {
 			tr {
-				&.tr1 { td:nth-child(6) { background-color : #FFF; } }
-				&.tr2 { td:nth-child(1), td:nth-child(2), td:nth-child(6), td:nth-child(7) { background-color : #FFF; } }
-				&.tr3 { td:nth-child(3), td:nth-child(5), td:nth-child(6) { background-color : #FFF; } }
-				&.tr4 { td:nth-child(4) { background-color: #FFF; } }
-				&.tr5 { td:nth-child(3), td:nth-child(5), td:nth-child(6) { background-color : #FFF; } }
-				&.tr6 { td:nth-child(1), td:nth-child(2), td:nth-child(6), td:nth-child(7) { background-color : #FFF; } }
-				&.tr6 { td:nth-child(7) { background-color : #FFF; } }
-				&.tr7 { td:nth-child(6) { background-color : #FFF; } }
+				&.tr1 { td:nth-child(6) { background-color : $a; } }
+				&.tr2 { td:nth-child(1), td:nth-child(2), td:nth-child(6), td:nth-child(7) { background-color : $a; } }
+				&.tr3 { td:nth-child(3), td:nth-child(5), td:nth-child(6) { background-color : $a; } }
+				&.tr4 { td:nth-child(4) { background-color: $a; } }
+				&.tr5 { td:nth-child(3), td:nth-child(5), td:nth-child(6) { background-color : $a; } }
+				&.tr6 { td:nth-child(1), td:nth-child(2), td:nth-child(6), td:nth-child(7) { background-color : $a; } }
+				&.tr6 { td:nth-child(7) { background-color : $a; } }
+				&.tr7 { td:nth-child(6) { background-color : $a; } }
+			}
+		}
+		.discard-table {
+			tr {
+				&.tr2 { td:nth-child(2), td:nth-child(6) { background-color : $a; } }
+				&.tr3 { td:nth-child(3), td:nth-child(5) { background-color : $a; } }
+				&.tr4 { td:nth-child(4) { background-color: $a; } }
+				&.tr5 { td:nth-child(3), td:nth-child(5) { background-color : $a; } }
+				&.tr6 { td:nth-child(2), td:nth-child(6) { background-color : $a; } }
 			}
 		}
 	}

--- a/src/creator.html
+++ b/src/creator.html
@@ -33,7 +33,7 @@
 			<li class="titles" aria-hidden="true" ng-class='{hidden:cards.length <= 0}'>
 				<h3>Front</h3><h3>Back</h3>
 			</li>
-			<li class="card" role="flashcard" ng-repeat="card in cards" ng-init="cardIndex = $index; startingTabIndex = cardIndex * 5 + 1;" id="card-{{cardIndex}}">
+			<li class="card" role="flashcard" ng-repeat="card in cards" ng-init="cardIndex = $index; startingTabIndex = cardIndex * 5 + 1;" id="card-{{cardIndex}}" ng-class="{'tall': card['front'].asset || card['back'].asset}">
 				<span class="num" ng-class="{large:cardIndex+1 >= 100}">{{cardIndex+1}}</span>
 				<span class="face" ng-repeat="face in ['front', 'back']" ng-init="cardFace = card[face]; faceText = cardFace.text" ng-attr-aria-label="Card {{face}}.">
 					<div class="center">
@@ -58,6 +58,17 @@
 							media-import="mediaImport"
 							asset="cardFace.asset"
 							ng-attr-tabindex='{{startingTabIndex + (face == "front" ? 0 : 2)}}'></div>
+					</div>
+					<div id="alt-text-container"
+					ng-show="cardFace.asset">
+						<label for="alt-text-input">Media Alt Text </label>
+						<input
+						type="text"
+						placeholder="Enter your alt text for the media here."
+						value="{{cardFace.asset.alt}}"
+						ng-model="cardFace.asset.alt"
+						id="alt-text-input"
+					/>
 					</div>
 					<div
 						class="alert"

--- a/src/creator.scss
+++ b/src/creator.scss
@@ -137,8 +137,13 @@ body {
 		perspective-origin : 50% 100%;
 		li {
 			margin : 0 0 15px 0;
-			height : 200px;
-	  		transform-style : preserve-3d;
+			height: 200px;
+			transform-style : preserve-3d;
+
+			&.tall {
+				height: 230px;
+			}
+
 			&.titles {
 				height : 60px;
 				margin : 0;
@@ -188,8 +193,6 @@ body {
 				.face {
 					position   : absolute;
 					width      : 400px;
-					height     : inherit;
-					background : #FFF;
 					overflow-y : auto;
 					overflow-x : hidden;
 					&:nth-child(3) { right : 0; }
@@ -202,6 +205,12 @@ body {
 						text-align : center;
 						&.title {
 							height : 25px;
+						}
+						&#alt-text-input {
+							width: 67%;
+							text-align: left;
+							padding: 0px 5px;
+							margin-left: 10px;
 						}
 					}
 					textarea { height : 130px; }
@@ -451,6 +460,9 @@ body {
 
 .center {
 	text-align: center;
+	position: relative;
+	background : #FFF;
+	max-height: inherit;
 }
 
 .hidden {

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -128,6 +128,8 @@ Namespace('Flashcards').Engine = do ->
 
 	# Stores card data.
 	# @data : Card information pulled from the qset.
+	# Front of card: 	answer
+	# Back of card: 	question
 	_storeCards = (data) ->
 		numCards   = data.length
 		_cardNodes = document.getElementsByClassName 'flashcard'
@@ -135,36 +137,38 @@ Namespace('Flashcards').Engine = do ->
 		for i in [0...numCards]
 			Flashcards.Card.push {}
 			_card = Flashcards.Card[i]
+			console.log("Data: ")
+			console.log(data[i])
 
 			# Single flashcard specific data.
 			_card.node      = _cardNodes[i]
-			_card.FrontText = data[i].answers[0].text.replace(/\&\#10\;/g, '<br>')
-			_card.BackText  = data[i].questions[0].text.replace(/\&\#10\;/g, '<br>')
+			_card.BackText = data[i].answers[0].text.replace(/\&\#10\;/g, '<br>')
+			_card.FrontText  = data[i].questions[0].text.replace(/\&\#10\;/g, '<br>')
 
 			# Strings that contain inline font scaling style (if applicable)
 			frontStyleStr = ""
 			backStyleStr = ""
 
-			if data[i].assets?[1]
-				# Handle former QSet asset format
-				if typeof data[i].assets[1] isnt 'object' and data[i].assets[1] isnt '-1'
-					_card.FrontURL = Materia.Engine.getImageAssetUrl data[i].assets[1]
-				# Handle new QSet asset format
-				else if typeof data[i].assets[1] is 'object'
-					_card.FrontURL = data[i].assets[1].url
-				# Assign alt text
-				_card.FrontAlt  = data[i].assets[1].alt;
-			else _card.FrontURL = '-1'
-
 			if data[i].assets?[0]
 				# Handle former QSet asset format
 				if typeof data[i].assets[0] isnt 'object' and data[i].assets[0] isnt '-1'
-					_card.BackURL = Materia.Engine.getImageAssetUrl data[i].assets[0]
+					_card.FrontURL = Materia.Engine.getImageAssetUrl data[i].assets[0]
 				# Handle new QSet asset format
 				else if typeof data[i].assets[0] is 'object'
-					_card.BackURL = data[i].assets[0].url
+					_card.FrontURL = data[i].assets[0].url
 				# Assign alt text
-				_card.BackAlt  = data[i].assets[0].alt;
+				_card.FrontAlt  = data[i].assets[0].alt;
+			else _card.FrontURL = '-1'
+
+			if data[i].assets?[1]
+				# Handle former QSet asset format
+				if typeof data[i].assets[1] isnt 'object' and data[i].assets[1] isnt '-1'
+					_card.BackURL = Materia.Engine.getImageAssetUrl data[i].assets[1]
+				# Handle new QSet asset format
+				else if typeof data[i].assets[1] is 'object'
+					_card.BackURL = data[i].assets[1].url
+				# Assign alt text
+				_card.BackAlt  = data[i].assets[1].alt;
 			else _card.BackURL = '-1'
 
 			if _card.FrontURL? && _card.FrontURL != '-1'
@@ -183,34 +187,47 @@ Namespace('Flashcards').Engine = do ->
 				computedBackFontSize = _computeFontSize _card.BackText
 				backStyleStr = 'style="font-size:'+computedBackFontSize+'px;'
 
-			# Aria label for flashcards
-			_card.FrontAriaLabel = _card.BackText + (if _card.FrontAlt then ". Media asset: " + _card.FrontAlt else "");
-			_card.BackAriaLabel  = _card.FrontText + (if _card.BackAlt then ". Media asset: " + _card.BackAlt else "");
-
-			# _card.node.children[0].setAttribute("aria-label", _card.FrontAriaLabel);
-			# _card.node.children[1].setAttribute("aria-label", _card.BackAriaLabel);
-
-			_card.node.children[0].children[0].innerHTML = '<p class="'+_frontClass+'" '+frontStyleStr+' ">'+_card.FrontText+'</p>'
+			_card.node.children[1].children[0].innerHTML = '<p class="'+_frontClass+'" '+frontStyleStr+' ">'+_card.FrontText+'</p>'
 			if _card.FrontURL isnt '-1'
-				if typeof data[i].assets[1] isnt 'object'
-					_card.node.children[0].children[1].innerHTML = '<img class="'+_frontClass+'" src="'+_card.FrontURL+'" alt="'+_card.FrontAlt+'">'
-				else if data[i].assets[1].type == 'jpg' or data[i].assets[1].type == 'jpeg' or data[i].assets[1].type == 'png' or data[i].assets[1].type == 'gif'
-					_card.node.children[0].children[1].innerHTML = '<img class="'+_frontClass+'" src="'+_card.FrontURL+'" alt="'+_card.FrontAlt+'">'
-				else if data[i].assets[1].type == 'mp3' || data[i].assets[1].type == 'wav' || data[i].assets[1].type == 'aif'
-					_card.node.children[0].children[1].innerHTML = '<audio controls class="'+_frontClass+'" src="'+_card.FrontURL+'">'
-				else if data[i].assets[1].type == 'link'
-					_card.node.children[0].children[1].innerHTML = '<iframe class="'+_frontClass+'" src="' + _card.FrontURL + '" frameborder="0" allowfullscreen></iframe>'
-
-			_card.node.children[1].children[0].innerHTML  = '<p class="'+_backClass+'" '+backStyleStr+' ">'+_card.BackText+'</p>'
-			if _card.BackURL isnt '-1'
 				if typeof data[i].assets[0] isnt 'object'
-					_card.node.children[1].children[1].innerHTML = '<img class="'+_backClass+'" src="'+_card.BackURL+'" alt="'+_card.BackAlt+'">'
+					_card.node.children[1].children[1].innerHTML = '<img class="'+_frontClass+'" src="'+_card.FrontURL+'" alt="'+_card.FrontAlt+'">'
+					_card.frontAssetType = "Image"
 				else if data[i].assets[0].type == 'jpg' or data[i].assets[0].type == 'jpeg' or data[i].assets[0].type == 'png' or data[i].assets[0].type == 'gif'
-					_card.node.children[1].children[1].innerHTML = '<img class="'+_backClass+'" src="'+_card.BackURL+'" alt="'+_card.BackAlt+'">'
+					_card.node.children[1].children[1].innerHTML = '<img class="'+_frontClass+'" src="'+_card.FrontURL+'" alt="'+_card.FrontAlt+'">'
+					_card.frontAssetType = "Image"
 				else if data[i].assets[0].type == 'mp3' || data[i].assets[0].type == 'wav' || data[i].assets[0].type == 'aif'
-					_card.node.children[1].children[1].innerHTML = '<audio controls class="'+_backClass+'" src="'+_card.BackURL+'">'
-				else if data[i].assets[0].type == 'link'
-					_card.node.children[1].children[1].innerHTML = '<iframe class="'+_backClass+'" src="' + _card.BackURL + '" frameborder="0" allowfullscreen></iframe>'
+					_card.node.children[1].children[1].innerHTML = '<audio controls class="'+_frontClass+'" src="'+_card.FrontURL+'">'
+					_card.frontAssetType = "Audio"
+				else if data[i].assets[0].type == 'link' or data[i].assets[0].type == 'youtube' or data[i].assets[0].type == 'vimeo'
+					_card.node.children[1].children[1].innerHTML = '<iframe class="'+_frontClass+'" src="' + _card.FrontURL + '" frameborder="0" allowfullscreen></iframe>'
+					_card.frontAssetType="Video"
+				else if data[i].assets[0].type == 'mp4'
+					_card.node.children[1].children[1].innerHTML = '<video class="'+_frontClass+'"><source src="' + _card.FrontURL + '">Your browser does not support the video tag</video>'
+					_card.frontAssetType="Video"
+
+			_card.node.children[0].children[0].innerHTML  = '<p class="'+_backClass+'" '+backStyleStr+' ">'+_card.BackText+'</p>'
+			if _card.BackURL isnt '-1'
+				if typeof data[i].assets[1] isnt 'object'
+					_card.node.children[0].children[1].innerHTML = '<img class="'+_backClass+'" src="'+_card.BackURL+'" alt="'+_card.BackAlt+'">'
+					_card.backAssetType = "Image"
+				else if data[i].assets[1].type == 'jpg' or data[i].assets[1].type == 'jpeg' or data[i].assets[1].type == 'png' or data[i].assets[1].type == 'gif'
+					_card.node.children[0].children[1].innerHTML = '<img class="'+_backClass+'" src="'+_card.BackURL+'" alt="'+_card.BackAlt+'">'
+					_card.backAssetType = "Image"
+				else if data[i].assets[1].type == 'mp3' or data[i].assets[1].type == 'wav' or data[i].assets[1].type == 'aif'
+					_card.node.children[0].children[1].innerHTML = '<audio controls class="'+_backClass+'" src="'+_card.BackURL+'">'
+					_card.backAssetType="Audio"
+				else if data[i].assets[1].type == 'link' or data[i].assets[1].type == 'youtube' or data[i].assets[1].type == 'vimeo'
+					_card.node.children[0].children[1].innerHTML = '<iframe class="'+_backClass+'" src="' + _card.BackURL + '" frameborder="0" allowfullscreen></iframe>'
+					_card.backAssetType="Video"
+				else if data[i].assets[1].type == 'mp4'
+					_card.node.children[0].children[1].innerHTML = '<video class="'+_backClass+'"><source src="' + _card.BackURL + '">Your browser does not support the video tag</video>'
+					_card.backAssetType="Video"
+
+			# Aria label for flashcards
+			_card.FrontAriaLabel = (if _card.FrontText then _card.FrontText + ", " else "") + (if _card.FrontURL isnt '-1' then _card.frontAssetType + " asset: " + (_card.FrontAlt or "Undescribed.") else "");
+			_card.BackAriaLabel  = (if _card.BackText then _card.BackText + ", " else "") + (if _card.BackURL isnt '-1' then _card.backAssetType + " asset: " + (_card.BackAlt or "Undescribed.") else "");
+			console.log("Card: ")
+			console.log(_card)
 
 	# Places cards in their correct positions within the gameboard and gives them a specific rotation.
 	# @face : Specifies whether or not to rotate the card when placing them in their positions.
@@ -442,8 +459,16 @@ Namespace('Flashcards').Engine = do ->
 			Flashcards.Card[id].node.setAttribute('tabindex', '0');
 			Flashcards.Card[id].node.setAttribute("aria-hidden", false);
 			# Show face content depending on rotation
-			Flashcards.Card[id].node.children[if face is 'front' then 1 else 0].setAttribute("aria-hidden", true);
-			Flashcards.Card[id].node.children[if face is 'front' then 0 else 1].setAttribute("aria-hidden", true);
+			if face is 'front'
+				# Front of card. Show contents if there is video or audio asset
+				Flashcards.Card[id].node.children[1].setAttribute("aria-hidden", (if Flashcards.Card[id].FrontURL isnt "-1" and Flashcards.Card[id].frontAssetType != "Image" then false else true));
+				# Always hide back of card
+				Flashcards.Card[id].node.children[0].setAttribute("aria-hidden", true);
+			else
+				# Back of card
+				Flashcards.Card[id].node.children[0].setAttribute("aria-hidden", (if Flashcards.Card[id].BackURL isnt "-1" and Flashcards.Card[id].backAssetType != "Image" then false else true));
+				# Always hide front of card
+				Flashcards.Card[id].node.children[1].setAttribute("aria-hidden", true);
 
 	_ariaHide = (id, isDiscardPile) ->
 		if (isDiscardPile)
@@ -475,7 +500,6 @@ Namespace('Flashcards').Engine = do ->
 				animating = true
 				setTimeout ->
 					animating = false
-					_ariaSetLiveRegion("All cards have been shuffled.")
 				, 1200
 
 				if atari then Flashcards.Atari.playIcon 'shuffle'
@@ -506,6 +530,7 @@ Namespace('Flashcards').Engine = do ->
 					Flashcards.Card = _shuffle(Flashcards.Card)
 					_setCardPositions(if rotation is '' then null else 'reverse')
 					nodes.icons[3].className = 'icon'
+					_ariaSetLiveRegion("All cards have been shuffled. Current card: " + (if Flashcards.Card[currentCardId].node.className is "flashcard rotated" then Flashcards.Card[currentCardId].BackAriaLabel else Flashcards.Card[currentCardId].FrontAriaLabel))
 				, 1500
 
 	_stageShufflePt1 = (card, i) ->
@@ -566,7 +591,7 @@ Namespace('Flashcards').Engine = do ->
 
 					nodes.icons[2].className = 'icon'
 
-					_ariaSetLiveRegion("All cards have been flipped")
+					_ariaSetLiveRegion("All cards have been flipped. Current card: " + (if Flashcards.Card[currentCardId].node.className is "flashcard rotated" then Flashcards.Card[currentCardId].BackAriaLabel else Flashcards.Card[currentCardId].FrontAriaLabel))
 				, 1400
 
 	# Decides if a flashcard node has any of the discard position classes.

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -66,6 +66,7 @@ Namespace('Flashcards').Engine = do ->
 	_hideInstructions = () ->
 		$('.instructions').hide()
 		$('#game').show()
+		$('#icon-help').focus()
 
 	_easterEggStart = () ->
 		yepnope(
@@ -296,6 +297,11 @@ Namespace('Flashcards').Engine = do ->
 				_killAudioVideo()
 				if _isDiscarded(this) then _unDiscard()
 				else _flipCard()
+			$('.flashcard').on    'keydown', (e) ->
+				if e.key is ' ' or e.key is 'Enter'
+					_killAudioVideo()
+					if _isDiscarded(this) then _unDiscard()
+					else _flipCard()
 
 			$('#icon-remove').on 'click', (e) ->
 				# Shuts off all audio players when card is discarded.
@@ -365,15 +371,19 @@ Namespace('Flashcards').Engine = do ->
 			if _canMove 'right'
 				nodes.rightArrow.className = 'arrow shown'
 				nodes.rightArrow.setAttribute("aria-hidden", false);
+				nodes.rightArrow.setAttribute("tabindex", "0");
 			else
 				nodes.rightArrow.className = 'arrow'
 				nodes.rightArrow.setAttribute("aria-hidden", true);
+				nodes.rightArrow.setAttribute("tabindex", "-1");
 			if _canMove 'left'
 				nodes.leftArrow.className  = 'arrow shown'
 				nodes.leftArrow.setAttribute("aria-hidden", false);
+				nodes.leftArrow.setAttribute("tabindex", "0");
 			else
 				nodes.leftArrow.className  = 'arrow'
 				nodes.leftArrow.setAttribute("aria-hidden", true);
+				nodes.leftArrow.setAttribute("tabindex", "-1");
 
 	# Rotates the current card 180 degrees.
 	_flipCard = () ->
@@ -408,8 +418,8 @@ Namespace('Flashcards').Engine = do ->
 			face = if Flashcards.DiscardPile[id].node.className is 'flashcard rotated' then 'back' else 'front';
 			Flashcards.DiscardPile[id].node.setAttribute('tabindex', '0');
 			Flashcards.DiscardPile[id].node.setAttribute("aria-hidden", false);
-			Flashcards.DiscardPile[id].node.setAttribute("aria-label", "Undiscard last card. " + numDiscard + " card" + (if numDiscard > 1 then "s" else "") + " in discard pile.");
-			Flashcards.DiscardPile[id].node.setAttribute("title",  "Undiscard last card.");
+			Flashcards.DiscardPile[id].node.setAttribute("aria-label", "Restore last card. " + numDiscard + " card" + (if numDiscard > 1 then "s" else "") + " in discard pile.");
+			Flashcards.DiscardPile[id].node.setAttribute("title",  "Restore last card.");
 			Flashcards.DiscardPile[id].node.children[if face is 'front' then 1 else 0].setAttribute("aria-hidden", false);
 			Flashcards.DiscardPile[id].node.children[if face is 'front' then 0 else 1].setAttribute("aria-hidden", true);
 		else
@@ -550,7 +560,7 @@ Namespace('Flashcards').Engine = do ->
 
 					nodes.icons[2].className = 'icon'
 
-					_ariaSetLiveRegion("Cards rotated.")
+					_ariaSetLiveRegion("Cards flipped.")
 				, 1400
 
 	# Decides if a flashcard node has any of the discard position classes.
@@ -668,10 +678,10 @@ Namespace('Flashcards').Engine = do ->
 					# then keep focus on last discard, otherwise focus flashcard
 					if (numDiscard > 0)
 						Flashcards.DiscardPile[numDiscard - 1].node.focus()
-						_ariaSetLiveRegion("Undiscarded card." + numDiscard + " left in discard pile.")
+						_ariaSetLiveRegion("Restored card." + numDiscard + " left in discard pile.")
 					else
 						Flashcards.Card[currentCardId].node.focus()
-						_ariaSetLiveRegion("Undiscarded card. No cards left in discard pile.")
+						_ariaSetLiveRegion("Restored card. No cards left in discard pile.")
 				, 400
 
 	_restoreTriggered = () ->
@@ -693,7 +703,7 @@ Namespace('Flashcards').Engine = do ->
 
 				_restoreTriggered()
 
-				_ariaSetLiveRegion("Undiscarding all cards.")
+				_ariaSetLiveRegion("Restoring all cards.")
 
 				# Move all cards from the discard pile into the active pile.
 				for i in [0...Flashcards.DiscardPile.length]
@@ -726,7 +736,7 @@ Namespace('Flashcards').Engine = do ->
 
 					setTimeout ->
 						document.getElementById("icon-finish").className = "icon unselectable"
-						_ariaSetLiveRegion("All cards have been un-discarded.")
+						_ariaSetLiveRegion("All cards have been restored.")
 					, 1200
 				, 20
 				_ariaUpdate()

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -727,7 +727,7 @@ Namespace('Flashcards').Engine = do ->
 			else
 				overlay = true
 				$('#overlay').show()
-				$('#left-arr').focus()
+				$('#icon-help').focus()
 
 			if nodes.helpOverlay.className is 'overlay shown'
 				_setArrowState()

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -261,11 +261,9 @@ Namespace('Flashcards').Engine = do ->
 					if _isDiscarded(this) then _unDiscard()
 					else _flipCard()
 
-			_removeNodes = document.getElementsByClassName('remove-button')
-			for i in [0..._removeNodes.length]
-				Hammer(_removeNodes[i]).on 'tap', (e) ->
-					_discard()
-					e.stopPropagation()
+			Hammer(document.getElementById('icon-remove')).on 'tap', (e) ->
+				_discard()
+				e.stopPropagation()
 		else
 			document.addEventListener upEventType, -> if overlay then _toggleOverlay()
 
@@ -321,12 +319,12 @@ Namespace('Flashcards').Engine = do ->
 				if _isDiscarded(this) then _unDiscard()
 				else _flipCard()
 
-			$('.remove-button').on 'mouseup', (e) ->
+			$('#icon-remove').on 'mouseup', (e) ->
 				# Shuts off all audio players when card is discarded.
 				_killAudioVideo()
 				_discard()
 				e.stopPropagation()
-			$('.remove-button').on 'click', (e) ->
+			$('#icon-remove').on 'click', (e) ->
 				# Shuts off all audio players when card is discarded.
 				_killAudioVideo()
 				_discard()
@@ -432,6 +430,7 @@ Namespace('Flashcards').Engine = do ->
 		lastDiscard = document.querySelector('.discarded-pos-'+(Flashcards.DiscardPile.length-1));
 		if (lastDiscard)
 			lastDiscard.setAttribute("aria-label", "Undiscard last card");
+			lastDiscard.setAttribute("title", "Undiscard last card");
 			lastDiscard.setAttribute("aria-hidden", "false");
 			lastDiscard.setAttribute("tabindex", "0");
 
@@ -614,8 +613,10 @@ Namespace('Flashcards').Engine = do ->
 						currentCardId--
 						Flashcards.Card[currentCardId].node.className = "flashcard "+(if rotation is '' then '' else 'rotated')
 
+				# Hide discarded deck from ARIA, except for top card
+				# Reveal current flashcard to ARIA
 				_ariaShowCurrent()
-				# Focus flashcard
+				# Focus current flashcard
 				Flashcards.Card[currentCardId].node.focus()
 
 				# Update arrows

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -447,7 +447,10 @@ Namespace('Flashcards').Engine = do ->
 			Flashcards.DiscardPile[id].node.setAttribute("aria-label", "Restore last card. " + numDiscard + " card" + (if numDiscard > 1 then "s" else "") + " in discard pile.");
 			Flashcards.DiscardPile[id].node.setAttribute("title",  "Restore last card.");
 			Flashcards.DiscardPile[id].node.children[if face is 'front' then 1 else 0].setAttribute("aria-hidden", false);
+			Flashcards.DiscardPile[id].node.children[if face is 'front' then 0 else 1].removeAttribute("inert");
 			Flashcards.DiscardPile[id].node.children[if face is 'front' then 0 else 1].setAttribute("aria-hidden", true);
+			Flashcards.DiscardPile[id].node.children[if face is 'front' then 0 else 1].setAttribute("inert", true);
+			Flashcards.DiscardPile[id].node.removeAttribute('inert');
 		else
 			# Get rotation
 			face = if Flashcards.Card[id].node.className is 'flashcard rotated' then 'back' else 'front';
@@ -458,25 +461,36 @@ Namespace('Flashcards').Engine = do ->
 			# Make flashcard tabbable and visible to screenreader
 			Flashcards.Card[id].node.setAttribute('tabindex', '0');
 			Flashcards.Card[id].node.setAttribute("aria-hidden", false);
+			Flashcards.Card[id].node.removeAttribute('inert');
 			# Show face content depending on rotation
 			if face is 'front'
 				# Front of card. Show contents if there is video or audio asset
 				Flashcards.Card[id].node.children[1].setAttribute("aria-hidden", (if Flashcards.Card[id].FrontURL isnt "-1" and Flashcards.Card[id].frontAssetType != "Image" then false else true));
+				Flashcards.Card[id].node.children[1].removeAttribute("inert");
 				# Always hide back of card
 				Flashcards.Card[id].node.children[0].setAttribute("aria-hidden", true);
+				Flashcards.Card[id].node.children[0].setAttribute("inert", true);
 			else
 				# Back of card
 				Flashcards.Card[id].node.children[0].setAttribute("aria-hidden", (if Flashcards.Card[id].BackURL isnt "-1" and Flashcards.Card[id].backAssetType != "Image" then false else true));
+				Flashcards.Card[id].node.children[0].removeAttribute("inert");
 				# Always hide front of card
 				Flashcards.Card[id].node.children[1].setAttribute("aria-hidden", true);
+				Flashcards.Card[id].node.children[1].setAttribute("inert", true);
 
 	_ariaHide = (id, isDiscardPile) ->
 		if (isDiscardPile)
 			Flashcards.DiscardPile[id].node.setAttribute("aria-hidden", true);
 			Flashcards.DiscardPile[id].node.setAttribute('tabindex', '-1');
+			Flashcards.DiscardPile[id].node.setAttribute('inert', true);
+			Flashcards.DiscardPile[id].node.children[0].setAttribute("aria-hidden", true);
+			Flashcards.DiscardPile[id].node.children[1].setAttribute("aria-hidden", true);
 		else
 			Flashcards.Card[id].node.setAttribute("aria-hidden", true);
 			Flashcards.Card[id].node.setAttribute('tabindex', '-1');
+			Flashcards.Card[id].node.setAttribute('inert', true);
+			Flashcards.Card[id].node.children[0].setAttribute("aria-hidden", true);
+			Flashcards.Card[id].node.children[1].setAttribute("aria-hidden", true);
 
 	_ariaSetLiveRegion = (msg) ->
 		document.getElementById("aria-updates").innerText = msg

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -475,7 +475,7 @@ Namespace('Flashcards').Engine = do ->
 				animating = true
 				setTimeout ->
 					animating = false
-					_ariaSetLiveRegion("Cards are shuffled.")
+					_ariaSetLiveRegion("All cards have been shuffled.")
 				, 1200
 
 				if atari then Flashcards.Atari.playIcon 'shuffle'
@@ -566,7 +566,7 @@ Namespace('Flashcards').Engine = do ->
 
 					nodes.icons[2].className = 'icon'
 
-					_ariaSetLiveRegion("Cards flipped.")
+					_ariaSetLiveRegion("All cards have been flipped")
 				, 1400
 
 	# Decides if a flashcard node has any of the discard position classes.
@@ -631,6 +631,8 @@ Namespace('Flashcards').Engine = do ->
 								_ariaSetLiveRegion("Discarded card. Next card: " + Flashcards.Card[currentCardId].FrontAriaLabel)
 							else
 								_ariaSetLiveRegion("Discarded card. Next card: " + Flashcards.Card[currentCardId].BackAriaLabel)
+						else
+							_ariaSetLiveRegion("Discarded card. There are no more cards. Press U to restore all cards.")
 					, (600)
 				, (if _len > 4 then 720 else 400)
 
@@ -745,7 +747,10 @@ Namespace('Flashcards').Engine = do ->
 
 					setTimeout ->
 						document.getElementById("icon-finish").className = "icon unselectable"
-						_ariaSetLiveRegion("All cards have been restored.")
+						if (Flashcards.Card[currentCardId].node.className = "flashcard rotated")
+							_ariaSetLiveRegion("All cards have been restored. Next card: " + Flashcards.Card[currentCardId].BackAriaLabel)
+						else
+							_ariaSetLiveRegion("All cards have been restored. Next card: " + Flashcards.Card[currentCardId].FrontAriaLabel)
 					, 1200
 				, 20
 				_ariaUpdate()

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -106,8 +106,6 @@ Namespace('Flashcards').Engine = do ->
 		_tFlashcard = $($('#t-flashcard').html())
 		nodes.$container.append _tFlashcard.clone() for i in [0...length]
 
-		if (nodes.$container.length > 0) then document.getElementById("container").firstChild.setAttribute("aria-hidden", false);
-
 	# Compute font scaling based on character length / scale factor. Max is 25px, min is 16px. ScaleFactor determines how quickly the font size is reduced.
 	# Scaling is appended to the card's <p> tag as an inline style
 	_computeFontSize = (text) ->
@@ -216,6 +214,8 @@ Namespace('Flashcards').Engine = do ->
 				if i is currentCardId
 					Flashcards.Card[i].node.className = 'flashcard rotated'
 					Flashcards.Card[i].node.setAttribute("aria-label", Flashcards.Card[i].FrontAriaLabel);
+					Flashcards.Card[i].node.setAttribute("aria-hidden", false);
+					Flashcards.Card[currentCardId].node.children[2].setAttribute("tabindex", 0);
 				else if i < currentCardId then Flashcards.Card[i].node.className = 'flashcard left-rotated'
 				else if i > currentCardId then Flashcards.Card[i].node.className = 'flashcard right-rotated'
 		else
@@ -224,6 +224,8 @@ Namespace('Flashcards').Engine = do ->
 				if i is currentCardId
 					Flashcards.Card[i].node.className = 'flashcard'
 					Flashcards.Card[i].node.setAttribute("aria-label", Flashcards.Card[i].BackAriaLabel);
+					Flashcards.Card[i].node.setAttribute("aria-hidden", false);
+					Flashcards.Card[currentCardId].node.children[2].setAttribute("tabindex", 0);
 				else if i < currentCardId then Flashcards.Card[i].node.className = 'flashcard left'
 				else if i > currentCardId then Flashcards.Card[i].node.className = 'flashcard right'
 
@@ -344,6 +346,8 @@ Namespace('Flashcards').Engine = do ->
 			# Move the current card in the specified direction.
 			Flashcards.Card[currentCardId].node.className = 'flashcard '+direction+rotation
 			Flashcards.Card[currentCardId].node.setAttribute("aria-hidden", true);
+			# Hide current card discard button
+			Flashcards.Card[currentCardId].node.children[2].setAttribute("tabindex", -1);
 
 			# Increment or decrement the current card ID.
 			currentCardId = if direction is 'left' then currentCardId+1 else currentCardId-1
@@ -351,8 +355,11 @@ Namespace('Flashcards').Engine = do ->
 			# Animate the new current card to the center.
 			Flashcards.Card[currentCardId].node.className = "flashcard "+(if rotation is '' then '' else 'rotated')
 			Flashcards.Card[currentCardId].node.setAttribute("aria-hidden", false);
-			console.log(rotation)
+
+			# Update aria-label based on card rotation
 			Flashcards.Card[currentCardId].node.setAttribute('aria-label', (if rotation is '' then Flashcards.Card[currentCardId].BackAriaLabel else Flashcards.Card[currentCardId].FrontAriaLabel));
+			# Make discard button visible
+			Flashcards.Card[currentCardId].node.children[2].setAttribute("tabindex", 0);
 
 			_setArrowState()
 

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -586,6 +586,7 @@ Namespace('Flashcards').Engine = do ->
 					_hideIcons()
 					_showElement nodes.finishMssg, true
 					nodes.container.className = 'hidden'
+					document.getElementById("icon-finish").focus()
 				else
 					if Flashcards.Card[currentCardId]?
 						Flashcards.Card[currentCardId].node.className = "flashcard "+(if rotation is '' then '' else 'rotated')
@@ -784,7 +785,7 @@ Namespace('Flashcards').Engine = do ->
 	_hideIcons = () ->
 		for i in [1...nodes.icons.length]
 			if (nodes.icons[i]).id != 'icon-finish'
-				nodes.icons[i].className = 'icon faded-out'
+				nodes.icons[i].className = 'icon hidden'
 
 	_showIcons = () ->
 		for i in [1...nodes.icons.length]

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -614,7 +614,7 @@ Namespace('Flashcards').Engine = do ->
 				# Update aria labels
 				_ariaUpdate()
 				# Focus current flashcard
-				Flashcards.Card[currentCardId]?.node.focus()
+				# Flashcards.Card[currentCardId]?.node.focus()
 
 				# Update arrows
 				_setArrowState()
@@ -625,8 +625,13 @@ Namespace('Flashcards').Engine = do ->
 				setTimeout ->
 					lastDiscard.remove();
 					document.getElementById('discardpile').append(lastDiscard);
-
-					_ariaSetLiveRegion("Discarded card.")
+					setTimeout ->
+						if numCards > 0
+							if Flashcards.Card[currentCardId].className = "flashcard rotated"
+								_ariaSetLiveRegion("Discarded card. Next card: " + Flashcards.Card[currentCardId].FrontAriaLabel)
+							else
+								_ariaSetLiveRegion("Discarded card. Next card: " + Flashcards.Card[currentCardId].BackAriaLabel)
+					, (600)
 				, (if _len > 4 then 720 else 400)
 
 

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -147,6 +147,8 @@ Namespace('Flashcards').Engine = do ->
 				# Handle new QSet asset format
 				else if typeof data[i].assets[1] is 'object'
 					_card.FrontURL = data[i].assets[1].url
+				# Assign alt text
+				_card.FrontAlt  = data[i].assets[1].alt;
 			else _card.FrontURL = '-1'
 
 			if data[i].assets?[0]
@@ -156,6 +158,8 @@ Namespace('Flashcards').Engine = do ->
 				# Handle new QSet asset format
 				else if typeof data[i].assets[0] is 'object'
 					_card.BackURL = data[i].assets[0].url
+				# Assign alt text
+				_card.BackAlt  = data[i].assets[0].alt;
 			else _card.BackURL = '-1'
 
 			if _card.FrontURL? && _card.FrontURL != '-1'
@@ -177,9 +181,9 @@ Namespace('Flashcards').Engine = do ->
 			_card.node.children[0].children[0].innerHTML = '<p class="'+_frontClass+'" '+frontStyleStr+' ">'+_card.FrontText+'</p>'
 			if _card.FrontURL isnt '-1'
 				if typeof data[i].assets[1] isnt 'object'
-					_card.node.children[0].children[1].innerHTML = '<img class="'+_frontClass+'" src="'+_card.FrontURL+'">'
+					_card.node.children[0].children[1].innerHTML = '<img class="'+_frontClass+'" src="'+_card.FrontURL+'" alt="'+_card.FrontAlt+'">'
 				else if data[i].assets[1].type == 'jpg' or data[i].assets[1].type == 'jpeg' or data[i].assets[1].type == 'png' or data[i].assets[1].type == 'gif'
-					_card.node.children[0].children[1].innerHTML = '<img class="'+_frontClass+'" src="'+_card.FrontURL+'">'
+					_card.node.children[0].children[1].innerHTML = '<img class="'+_frontClass+'" src="'+_card.FrontURL+'" alt="'+_card.FrontAlt+'">'
 				else if data[i].assets[1].type == 'mp3' || data[i].assets[1].type == 'wav' || data[i].assets[1].type == 'aif'
 					_card.node.children[0].children[1].innerHTML = '<audio controls class="'+_frontClass+'" src="'+_card.FrontURL+'">'
 				else if data[i].assets[1].type == 'link'
@@ -188,9 +192,9 @@ Namespace('Flashcards').Engine = do ->
 			_card.node.children[1].children[0].innerHTML  = '<p class="'+_backClass+'" '+backStyleStr+' ">'+_card.BackText+'</p>'
 			if _card.BackURL isnt '-1'
 				if typeof data[i].assets[0] isnt 'object'
-					_card.node.children[1].children[1].innerHTML = '<img class="'+_backClass+'" src="'+_card.BackURL+'">'
+					_card.node.children[1].children[1].innerHTML = '<img class="'+_backClass+'" src="'+_card.BackURL+'" alt="'+_card.BackAlt+'">'
 				else if data[i].assets[0].type == 'jpg' or data[i].assets[0].type == 'jpeg' or data[i].assets[0].type == 'png' or data[i].assets[0].type == 'gif'
-					_card.node.children[1].children[1].innerHTML = '<img class="'+_backClass+'" src="'+_card.BackURL+'">'
+					_card.node.children[1].children[1].innerHTML = '<img class="'+_backClass+'" src="'+_card.BackURL+'" alt="'+_card.BackAlt+'">'
 				else if data[i].assets[0].type == 'mp3' || data[i].assets[0].type == 'wav' || data[i].assets[0].type == 'aif'
 					_card.node.children[1].children[1].innerHTML = '<audio controls class="'+_backClass+'" src="'+_card.BackURL+'">'
 				else if data[i].assets[0].type == 'link'
@@ -293,24 +297,20 @@ Namespace('Flashcards').Engine = do ->
 
 		# Key events for keyboardz.
 		window.addEventListener 'keydown', (e) ->
-			switch e.keyCode
-				when 37     then _leftSelected()                             # Left arrow key.
-				when 65     then _leftSelected()                             # A key.
-				when 38     then _unDiscard()                                # Up arrow key.
-				when 87     then _unDiscard()                                # W key.
-				when 39     then _rightSelected()                            # Right arrow key.
-				when 68     then _rightSelected()                            # D key.
-				when 40     then _discard()                                  # Down arrow key.
-				when 88     then _discard()                                  # X key.
-				when 32, 70 then _flipCard()                                 # F key and space bar.
-				when 72     then _toggleOverlay()                            # H key.
-				when 82     then _rotateCards(if rotation is '' then 'back') # R key.
-				when 83     then _shuffleCards()                             # S key.
-				when 85     then _unDiscardAll()                             # U key.
-				when 27		then
+			switch e.key
+				when 'ArrowLeft', 'a'   	then _leftSelected()
+				when 'ArrowUp', 'w'     	then _unDiscard()
+				when 'ArrowRight', 'd'     	then _rightSelected()
+				when 'd'     				then _rightSelected()
+				when 'ArrowDown', 'x'     	then _discard()
+				when 'f' 					then _flipCard()
+				when 'h'     				then _toggleOverlay()
+				when 'r'     				then _rotateCards(if rotation is '' then 'back')
+				when 's'     				then _shuffleCards()
+				when 'u'     				then _unDiscardAll()
+				# when 27		then
 
 			_killAudioVideo()
-			e.preventDefault()
 
 	_leftSelected = ()  -> if _canMove 'left'  then _shiftCards 'right'
 	_rightSelected = () -> if _canMove 'right' then _shiftCards 'left'
@@ -651,7 +651,8 @@ Namespace('Flashcards').Engine = do ->
 
 	_hideIcons = () ->
 		for i in [1...nodes.icons.length]
-			nodes.icons[i].className = 'icon faded-out'
+			if (nodes.icons[i]).id != 'icon-finish'
+				nodes.icons[i].className = 'icon faded-out'
 
 	_showIcons = () ->
 		for i in [1...nodes.icons.length]

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -180,6 +180,11 @@ Namespace('Flashcards').Engine = do ->
 				computedBackFontSize = _computeFontSize _card.BackText
 				backStyleStr = 'style="font-size:'+computedBackFontSize+'px;'
 
+			_card.FrontAriaLabel = _card.FrontText + (if _card.FrontAlt then ". Media asset: " + _card.FrontAlt else "");
+			_card.BackAriaLabel  = _card.BackText + (if _card.BackAlt then ". Media asset: " + _card.BackAlt else "");
+
+			_card.node.setAttribute("aria-label", _card.FrontAriaLabel);
+
 			_card.node.children[0].children[0].innerHTML = '<p class="'+_frontClass+'" '+frontStyleStr+' ">'+_card.FrontText+'</p>'
 			if _card.FrontURL isnt '-1'
 				if typeof data[i].assets[1] isnt 'object'
@@ -208,13 +213,17 @@ Namespace('Flashcards').Engine = do ->
 		if face is 'reverse'
 			rotation = '-rotated'
 			for i in [0...numCards]
-				if i is currentCardId     then Flashcards.Card[i].node.className = 'flashcard rotated'
+				if i is currentCardId
+					Flashcards.Card[i].node.className = 'flashcard rotated'
+					Flashcards.Card[i].node.setAttribute("aria-label", Flashcards.Card[i].FrontAriaLabel);
 				else if i < currentCardId then Flashcards.Card[i].node.className = 'flashcard left-rotated'
 				else if i > currentCardId then Flashcards.Card[i].node.className = 'flashcard right-rotated'
 		else
 			rotation = ''
 			for i in [0...numCards]
-				if i is currentCardId     then Flashcards.Card[i].node.className = 'flashcard'
+				if i is currentCardId
+					Flashcards.Card[i].node.className = 'flashcard'
+					Flashcards.Card[i].node.setAttribute("aria-label", Flashcards.Card[i].BackAriaLabel);
 				else if i < currentCardId then Flashcards.Card[i].node.className = 'flashcard left'
 				else if i > currentCardId then Flashcards.Card[i].node.className = 'flashcard right'
 
@@ -342,6 +351,8 @@ Namespace('Flashcards').Engine = do ->
 			# Animate the new current card to the center.
 			Flashcards.Card[currentCardId].node.className = "flashcard "+(if rotation is '' then '' else 'rotated')
 			Flashcards.Card[currentCardId].node.setAttribute("aria-hidden", false);
+			console.log(rotation)
+			Flashcards.Card[currentCardId].node.setAttribute('aria-label', (if rotation is '' then Flashcards.Card[currentCardId].BackAriaLabel else Flashcards.Card[currentCardId].FrontAriaLabel));
 
 			_setArrowState()
 
@@ -357,13 +368,11 @@ Namespace('Flashcards').Engine = do ->
 			# The back is currently showing.
 			if Flashcards.Card[currentCardId].node.className is 'flashcard rotated'
 				Flashcards.Card[currentCardId].node.className = 'flashcard'
-				document.querySelector(".back").setAttribute("aria-hidden", false)
-				document.querySelector(".front").setAttribute("aria-hidden", true)
+				Flashcards.Card[currentCardId].node.setAttribute('aria-label', Flashcards.Card[currentCardId].BackAriaLabel);
 			# The front is currently showing.
 			else
-				document.querySelector(".back").setAttribute("aria-hidden", true)
-				document.querySelector(".front").setAttribute("aria-hidden", false)
 				Flashcards.Card[currentCardId].node.className = 'flashcard rotated'
+				Flashcards.Card[currentCardId].node.setAttribute('aria-label', Flashcards.Card[currentCardId].FrontAriaLabel);
 
 	_killAudioVideo = () ->
 		$('audio').each ->
@@ -511,10 +520,10 @@ Namespace('Flashcards').Engine = do ->
 					nodes.container.className = 'hidden'
 				else
 					if Flashcards.Card[currentCardId]?
-						Flashcards.Card[currentCardId].node.className = "flashcard hidden "+(if rotation is '' then '' else 'rotated')
+						Flashcards.Card[currentCardId].node.className = "flashcard "+(if rotation is '' then '' else 'rotated')
 					else
 						currentCardId--
-						Flashcards.Card[currentCardId].node.className = "flashcard hidden "+(if rotation is '' then '' else 'rotated')
+						Flashcards.Card[currentCardId].node.className = "flashcard "+(if rotation is '' then '' else 'rotated')
 
 				_setArrowState()
 

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -267,48 +267,26 @@ Namespace('Flashcards').Engine = do ->
 		else
 			document.addEventListener upEventType, -> if overlay then _toggleOverlay()
 
-			$('#icon-left').on    'mouseup', ->
-				_leftSelected()
-				_killAudioVideo()
 			$('#icon-left').on    'click', ->
 				_leftSelected()
-				_killAudioVideo()
-			$('#icon-right').on   'mouseup', ->
-				_rightSelected()
 				_killAudioVideo()
 			$('#icon-right').on   'click', ->
 				_rightSelected()
 				_killAudioVideo()
-			$('#icon-help').on    'mouseup', _toggleOverlay
 			$('#icon-help').on    'click', _toggleOverlay
-			$('#icon-restore').on 'mouseup', ->
-				_killAudioVideo()
-				_unDiscardAll()
 			$('#icon-restore').on 'click', ->
-				_killAudioVideo()
-				_unDiscardAll()
-			$('#icon-finish').on  'mouseup', ->
 				_killAudioVideo()
 				_unDiscardAll()
 			$('#icon-finish').on  'click', ->
 				_killAudioVideo()
 				_unDiscardAll()
-			$('#icon-rotate').on  'mouseup', ->
-				_killAudioVideo()
-				_rotateCards(if rotation is '' then 'back')
 			$('#icon-rotate').on  'click', ->
 				_killAudioVideo()
 				_rotateCards(if rotation is '' then 'back')
-			$('#icon-shuffle').on 'mouseup', ->
-				_killAudioVideo()
-				_shuffleCards()
 			$('#icon-shuffle').on 'click', ->
 				_killAudioVideo()
 				_shuffleCards()
 
-			$('audio').on    'mouseup', (e)->
-				if _isDiscarded(this) then _unDiscard()
-				else e.stopPropagation()
 			$('audio').on    'click', (e)->
 				if _isDiscarded(this) then _unDiscard()
 				else e.stopPropagation()
@@ -319,11 +297,6 @@ Namespace('Flashcards').Engine = do ->
 				if _isDiscarded(this) then _unDiscard()
 				else _flipCard()
 
-			$('#icon-remove').on 'mouseup', (e) ->
-				# Shuts off all audio players when card is discarded.
-				_killAudioVideo()
-				_discard()
-				e.stopPropagation()
 			$('#icon-remove').on 'click', (e) ->
 				# Shuts off all audio players when card is discarded.
 				_killAudioVideo()

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -106,6 +106,8 @@ Namespace('Flashcards').Engine = do ->
 		_tFlashcard = $($('#t-flashcard').html())
 		nodes.$container.append _tFlashcard.clone() for i in [0...length]
 
+		if (nodes.$container.length > 0) then document.getElementById("container").firstChild.setAttribute("aria-hidden", false);
+
 	# Compute font scaling based on character length / scale factor. Max is 25px, min is 16px. ScaleFactor determines how quickly the font size is reduced.
 	# Scaling is appended to the card's <p> tag as an inline style
 	_computeFontSize = (text) ->
@@ -332,12 +334,14 @@ Namespace('Flashcards').Engine = do ->
 
 			# Move the current card in the specified direction.
 			Flashcards.Card[currentCardId].node.className = 'flashcard '+direction+rotation
+			Flashcards.Card[currentCardId].node.setAttribute("aria-hidden", true);
 
 			# Increment or decrement the current card ID.
 			currentCardId = if direction is 'left' then currentCardId+1 else currentCardId-1
 
 			# Animate the new current card to the center.
 			Flashcards.Card[currentCardId].node.className = "flashcard "+(if rotation is '' then '' else 'rotated')
+			Flashcards.Card[currentCardId].node.setAttribute("aria-hidden", false);
 
 			_setArrowState()
 
@@ -353,8 +357,12 @@ Namespace('Flashcards').Engine = do ->
 			# The back is currently showing.
 			if Flashcards.Card[currentCardId].node.className is 'flashcard rotated'
 				Flashcards.Card[currentCardId].node.className = 'flashcard'
+				document.querySelector(".back").setAttribute("aria-hidden", false)
+				document.querySelector(".front").setAttribute("aria-hidden", true)
 			# The front is currently showing.
 			else
+				document.querySelector(".back").setAttribute("aria-hidden", true)
+				document.querySelector(".front").setAttribute("aria-hidden", false)
 				Flashcards.Card[currentCardId].node.className = 'flashcard rotated'
 
 	_killAudioVideo = () ->
@@ -503,10 +511,10 @@ Namespace('Flashcards').Engine = do ->
 					nodes.container.className = 'hidden'
 				else
 					if Flashcards.Card[currentCardId]?
-						Flashcards.Card[currentCardId].node.className = "flashcard "+(if rotation is '' then '' else 'rotated')
+						Flashcards.Card[currentCardId].node.className = "flashcard hidden "+(if rotation is '' then '' else 'rotated')
 					else
 						currentCardId--
-						Flashcards.Card[currentCardId].node.className = "flashcard "+(if rotation is '' then '' else 'rotated')
+						Flashcards.Card[currentCardId].node.className = "flashcard hidden "+(if rotation is '' then '' else 'rotated')
 
 				_setArrowState()
 
@@ -662,3 +670,4 @@ Namespace('Flashcards').Engine = do ->
 	start : start
 	nodes : nodes
 	hideInstructions : _hideInstructions
+	toggleOverlay : _toggleOverlay

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -157,7 +157,7 @@ Namespace('Flashcards').Engine = do ->
 				else if typeof data[i].assets[0] is 'object'
 					_card.FrontURL = data[i].assets[0].url
 				# Assign alt text
-				_card.FrontAlt  = data[i].assets[0].alt;
+				_card.FrontAlt  = data[i].assets[0].alt or "Undescribed";
 			else _card.FrontURL = '-1'
 
 			if data[i].assets?[1]
@@ -168,7 +168,7 @@ Namespace('Flashcards').Engine = do ->
 				else if typeof data[i].assets[1] is 'object'
 					_card.BackURL = data[i].assets[1].url
 				# Assign alt text
-				_card.BackAlt  = data[i].assets[1].alt;
+				_card.BackAlt  = data[i].assets[1].alt or "Undescribed";
 			else _card.BackURL = '-1'
 
 			if _card.FrontURL? && _card.FrontURL != '-1'

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -179,8 +179,8 @@ Namespace('Flashcards').Engine = do ->
 				backStyleStr = 'style="font-size:'+computedBackFontSize+'px;'
 
 			# Aria label for flashcards
-			# _card.FrontAriaLabel = _card.FrontText + (if _card.FrontAlt then ". Media asset: " + _card.FrontAlt else "");
-			# _card.BackAriaLabel  = _card.BackText + (if _card.BackAlt then ". Media asset: " + _card.BackAlt else "");
+			_card.FrontAriaLabel = _card.BackText + (if _card.FrontAlt then ". Media asset: " + _card.FrontAlt else "");
+			_card.BackAriaLabel  = _card.FrontText + (if _card.BackAlt then ". Media asset: " + _card.BackAlt else "");
 
 			# _card.node.children[0].setAttribute("aria-label", _card.FrontAriaLabel);
 			# _card.node.children[1].setAttribute("aria-label", _card.BackAriaLabel);
@@ -408,21 +408,22 @@ Namespace('Flashcards').Engine = do ->
 			face = if Flashcards.DiscardPile[id].node.className is 'flashcard rotated' then 'back' else 'front';
 			Flashcards.DiscardPile[id].node.setAttribute('tabindex', '0');
 			Flashcards.DiscardPile[id].node.setAttribute("aria-hidden", false);
-			Flashcards.DiscardPile[id].node.setAttribute("aria-label", "Undiscard last card. " + numDiscard + " card" + (if numDiscard > 1 then "s") + " in discard pile.");
+			Flashcards.DiscardPile[id].node.setAttribute("aria-label", "Undiscard last card. " + numDiscard + " card" + (if numDiscard > 1 then "s" else "") + " in discard pile.");
 			Flashcards.DiscardPile[id].node.setAttribute("title",  "Undiscard last card.");
 			Flashcards.DiscardPile[id].node.children[if face is 'front' then 1 else 0].setAttribute("aria-hidden", false);
 			Flashcards.DiscardPile[id].node.children[if face is 'front' then 0 else 1].setAttribute("aria-hidden", true);
 		else
 			# Get rotation
-			face = if Flashcards.Card[currentCardId].node.className is 'flashcard rotated' then 'back' else 'front';
+			face = if Flashcards.Card[id].node.className is 'flashcard rotated' then 'back' else 'front';
 			# Set Flashcard parent aria label
-			Flashcards.Card[id].node.setAttribute('aria-label', (if face is 'front' then "flashcard front" else "flashcard back"));
+			# Flashcards.Card[id].node.setAttribute('aria-label', (if face is 'front' then "flashcard front" else "flashcard back"));
+			Flashcards.Card[id].node.setAttribute('aria-label', if face is 'front' then Flashcards.Card[id].FrontAriaLabel else Flashcards.Card[id].BackAriaLabel)
 			Flashcards.Card[id].node.setAttribute("title", "Flip card");
 			# Make flashcard tabbable and visible to screenreader
 			Flashcards.Card[id].node.setAttribute('tabindex', '0');
 			Flashcards.Card[id].node.setAttribute("aria-hidden", false);
 			# Show face content depending on rotation
-			Flashcards.Card[id].node.children[if face is 'front' then 1 else 0].setAttribute("aria-hidden", false);
+			Flashcards.Card[id].node.children[if face is 'front' then 1 else 0].setAttribute("aria-hidden", true);
 			Flashcards.Card[id].node.children[if face is 'front' then 0 else 1].setAttribute("aria-hidden", true);
 
 	_ariaHide = (id, isDiscardPile) ->

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -28,12 +28,13 @@ Namespace('Flashcards').Engine = do ->
 
 	# Called by Materia.Engine when widget Engine should start the UI.
 	start = (instance, qset, version = '1') ->
+
+		$('#game').hide()
+		$('#overlay').hide()
+
 		if not _browserSupportsSvg()
 			$('.error-notice-container').show()
 			return
-
-		Hammer(document.getElementById('gotit')).on 'tap', ->
-			$('.instructions').hide()
 
 		if instance.name is undefined or null
 			instance.name = "Widget Title Goes Here"
@@ -61,6 +62,10 @@ Namespace('Flashcards').Engine = do ->
 
 	_browserSupportsSvg = ->
 		typeof SVGRect != "undefined"
+
+	_hideInstructions = () ->
+		$('.instructions').hide()
+		$('#game').show()
 
 	_easterEggStart = () ->
 		yepnope(
@@ -290,14 +295,19 @@ Namespace('Flashcards').Engine = do ->
 		window.addEventListener 'keydown', (e) ->
 			switch e.keyCode
 				when 37     then _leftSelected()                             # Left arrow key.
+				when 65     then _leftSelected()                             # A key.
 				when 38     then _unDiscard()                                # Up arrow key.
+				when 87     then _unDiscard()                                # W key.
 				when 39     then _rightSelected()                            # Right arrow key.
+				when 68     then _rightSelected()                            # D key.
 				when 40     then _discard()                                  # Down arrow key.
+				when 88     then _discard()                                  # X key.
 				when 32, 70 then _flipCard()                                 # F key and space bar.
 				when 72     then _toggleOverlay()                            # H key.
 				when 82     then _rotateCards(if rotation is '' then 'back') # R key.
 				when 83     then _shuffleCards()                             # S key.
 				when 85     then _unDiscardAll()                             # U key.
+				when 27		then
 
 			_killAudioVideo()
 			e.preventDefault()
@@ -602,7 +612,13 @@ Namespace('Flashcards').Engine = do ->
 				animating = false
 			, 300
 
-			if overlay is true then overlay = false else overlay = true
+			if overlay is true
+				overlay = false
+				$('#overlay').hide()
+			else
+				overlay = true
+				$('#overlay').show()
+				$('#left-arr').focus()
 
 			if nodes.helpOverlay.className is 'overlay shown'
 				_setArrowState()
@@ -644,3 +660,4 @@ Namespace('Flashcards').Engine = do ->
 	# Public.
 	start : start
 	nodes : nodes
+	hideInstructions : _hideInstructions

--- a/src/player.html
+++ b/src/player.html
@@ -33,13 +33,13 @@
 		</section>
 
 		<section id="instructions" class="instructions">
-			<div class="dialog" role="dialog" aria-describedby="tutorial-desc" aria-labelledby="tutorial-header">
+			<div class="dialog" role="dialog" aria-describedby="tutorial-desc tutorial-instructions tutorial-image" aria-labelledby="tutorial-header">
 				<h2 id="tutorial-header">Studying with Flash Cards</h2>
 				<p id="tutorial-desc">This is a virtual deck of two-sided cards that you can use to help you study.</p>
 				<figure>
-					<img src="assets/intro.svg" alt="Locations of controls. Press H after clicking Got It! to learn key bindings.">
-					<ul>
-						<li>Click cards to flip them - See if you guessed the correct answer.</li>
+					<img src="assets/intro.svg"  id="tutorial-image" alt="Locations of controls. Press H after clicking Got It! to learn key bindings.">
+					<ul id="tutorial-instructions">
+						<li>Click cards to flip them and see if you guessed the correct answer.</li>
 						<li>Discard a card when you feel confident that you know it.</li>
 						<li>Shuffle the deck or flip all the cards and try to guess the other side.</li>
 					</ul>

--- a/src/player.html
+++ b/src/player.html
@@ -32,54 +32,79 @@
 			<p class="load">Loading User Data from file:- SHELLCFG/DAT   <span class="dot">.</span><span class="dot">.</span><span class="dot">.</span></p>
 		</section>
 
-		<section id="game">
-			<section id="atari-bg" aria-hidden="true"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></section>
+		<div id="instructions" class="instructions">
+			<div class="dialog" role="dialog" aria-describedby="tutorial-desc" aria-labelledby="tutorial-header">
+				<h2 id="tutorial-header">Studying with Flash Cards</h2>
+				<p id="tutorial-desc">This is a virtual deck of two-sided cards that you can use to help you study.</p>
+				<figure>
+					<img src="assets/intro.svg" alt="Locations of controls. Press H after clicking Got It! to learn key bindings.">
+					<ul>
+						<li>Click cards to flip them - See if you guessed the correct answer.</li>
+						<li>Discard a card when you feel confident that you know it.</li>
+						<li>Shuffle the deck or flip all the cards and try to guess the other side.</li>
+					</ul>
+				</figure>
+				<button id="gotit" class="gotit" tabindex="0" onclick="Namespace('Flashcards').Engine.hideInstructions()">Got it!</button>
+			</div>
+		</div>
 
-			<section id="overlay" class="overlay" aria-hidden="true">
-				<div class="arr box" id="left-arr">previous card</div>
-				<svg class="arr" id="left-arr">
+		<div class="error-notice-container">
+			<div class="error-notice">
+				<h1>This widget uses features that your browser doesn't support</h1>
+				<h2>Upgrade your browser to use this widget</h2>
+			</div>
+		</div>
+
+		<section id="game">
+			<section id="atari-bg"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></section>
+
+			<div id="icon-help" role="button" class="icon" aria-label="Press H for help"></div>
+
+			<section id="overlay" class="overlay">
+				<div class="arr box" id="left-arr">previous card - A</div tabindex="0">
+				<svg class="arr" id="left-arr" aria-hidden="true">
 					<path d="M40 0 L20 65 Z"></path>
 					<circle cx="20" cy="65" r="7"></circle>
 				</svg>
 
-				<div class="arr box" id="right-arr">next card</div>
-				<svg class="arr" id="right-arr">
+				<div class="arr box" id="right-arr" tabindex="0">next card - D</div>
+				<svg class="arr" id="right-arr" aria-hidden="true">
 					<path d="M10 0 L30 65 Z"></path>
 					<circle cx="30" cy="65" r="7"></circle>
 				</svg>
 
-				<div id="flip" class="box">flip card</div>
-				<svg class="arr" id="mid-arr">
+				<div id="flip" class="box" tabindex="0">flip card - F</div>
+				<svg class="arr" id="mid-arr" aria-hidden="true">
 					<path d="M25 0 L25 65 Z"></path>
 					<circle cx="25" cy="65" r="7"></circle>
 				</svg>
 
-				<div id="discard" class="box">discard</div>
-				<svg class="arr" id="right-arr-2">
+				<div id="discard" class="box" tabindex="0">discard - X</div>
+				<svg class="arr" id="right-arr-2" aria-hidden="true">
 					<path d="M30 0 L10 48 Z"></path>
 					<circle cx="10" cy="48" r="7"></circle>
 				</svg>
 
-				<div id="rotate" class="box">rotate cards</div>
-				<svg class="arr" id="bottom-mid-arr">
+				<div id="rotate" class="box" tabindex="0">rotate cards - R</div>
+				<svg class="arr" id="bottom-mid-arr" aria-hidden="true">
 					<path d="M25 0 L25 45 Z"></path>
 					<circle cx="25" cy="45" r="7"></circle>
 				</svg>
 
-				<div id="shuffle" class="box">shuffle cards</div>
-				<svg class="arr" id="bottom-right-arr">
+				<div id="shuffle" class="box" tabindex="0">shuffle cards - S</div>
+				<svg class="arr" id="bottom-right-arr" aria-hidden="true">
 					<path d="M30 0 L10 25 Z"></path>
 					<circle cx="10" cy="25" r="7"></circle>
 				</svg>
 
-				<div id="restore-one" class="box">restore last discard</div>
-				<svg class="arr" id="bottom-horiz-arr">
-					<path d="M5 20 L40 20 Z"></path>
+				<div id="restore-one" class="box" tabindex="0">restore last discard - W</div>
+				<svg class="arr" id="bottom-horiz-arr" aria-hidden="true">
+					<path d="M40 20 L25 20 Z"></path>
 					<circle cx="40" cy="20" r="7"></circle>
 				</svg>
 
-				<div id="restore-all" class="box">restore deck</div>
-				<svg class="arr" id="bottom-left-arr">
+				<div id="restore-all" class="box" tabindex="0">restore deck - U</div>
+				<svg class="arr" id="bottom-left-arr" aria-hidden="true">
 					<path d="M5 0 L35 25 Z"></path>
 					<circle cx="35" cy="25" r="7"></circle>
 				</svg>
@@ -112,32 +137,7 @@
 				<div aria-label="Shuffle cards." id="icon-shuffle" class="icon"></div>
 
 			</section>
-
-			<div id="icon-help" class="icon" aria-hidden="true"></div>
 		</section>
-
-		<div id="instructions" class="instructions">
-			<div class="dialog">
-				<h2>Studying with Flash Cards</h2>
-				<p>This is a virtual deck of two-sided cards that you can use to help you study.</p>
-				<figure>
-					<img src="assets/intro.svg">
-					<ul>
-						<li>Click cards to flip them - See if you guessed the correct answer.</li>
-						<li>Discard a card when you feel confident that you know it.</li>
-						<li>Shuffle the deck or flip all the cards and try to guess the other side.</li>
-					</ul>
-				</figure>
-				<div id="gotit" class="gotit">Got it!</div>
-			</div>
-		</div>
-
-		<div class="error-notice-container">
-			<div class="error-notice">
-				<h1>This widget uses features that your browser doesn't support</h1>
-				<h2>Upgrade your browser to use this widget</h2>
-			</div>
-		</div>
 
 	</body>
 

--- a/src/player.html
+++ b/src/player.html
@@ -32,7 +32,7 @@
 			<p class="load">Loading User Data from file:- SHELLCFG/DAT   <span class="dot">.</span><span class="dot">.</span><span class="dot">.</span></p>
 		</section>
 
-		<div id="instructions" class="instructions">
+		<section id="instructions" class="instructions">
 			<div class="dialog" role="dialog" aria-describedby="tutorial-desc" aria-labelledby="tutorial-header">
 				<h2 id="tutorial-header">Studying with Flash Cards</h2>
 				<p id="tutorial-desc">This is a virtual deck of two-sided cards that you can use to help you study.</p>
@@ -46,22 +46,35 @@
 				</figure>
 				<button id="gotit" class="gotit" tabindex="0" onclick="Namespace('Flashcards').Engine.hideInstructions()">Got it!</button>
 			</div>
-		</div>
+		</section>
 
-		<div class="error-notice-container">
-			<div class="error-notice">
-				<h1>This widget uses features that your browser doesn't support</h1>
-				<h2>Upgrade your browser to use this widget</h2>
+		<section class="error-notice-container">
+			<div class="error-notice"
+			role="alertdialog"
+			aria-modal="true"
+			aria-describedby="error-notice-desc"
+			aria-labelledby="error-notice-title">
+				<h1 id="error-notice-title">This widget uses features that your browser doesn't support</h1>
+				<h2 id="error-notice-desc">Upgrade your browser to use this widget</h2>
 			</div>
-		</div>
+		</section>
 
 		<section id="game">
-			<section id="atari-bg"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></section>
+			<section id="atari-bg" aria-hidden="true">
+				<div></div>
+				<div></div>
+				<div></div>
+				<div></div>
+				<div></div>
+				<div></div>
+				<div></div>
+				<div></div>
+			</section>
 
-			<div id="icon-help" role="button" class="icon" aria-label="Press H for help"></div>
+			<button id="icon-help" class="icon" aria-label="Press H for help"></button>
 
 			<section id="overlay" class="overlay">
-				<div class="arr box" id="left-arr">previous card - A</div tabindex="0">
+				<div class="arr box" id="left-arr" tabindex="0">previous card - A</div>
 				<svg class="arr" id="left-arr" aria-hidden="true">
 					<path d="M40 0 L20 65 Z"></path>
 					<circle cx="20" cy="65" r="7"></circle>
@@ -112,47 +125,44 @@
 				<div id="dummy-card"></div>
 			</section>
 
-			<section id="board">
+			<main id="board">
 
-				<div id="instance-title"></div>
+				<h1 id="instance-title"></h1>
 
 				<!-- arrows -->
-				<div id="icon-left" class="arrow"></div>
-				<div id="icon-right" class="arrow shown"></div>
+				<button id="icon-left" class="arrow"></button>
+				<button id="icon-right" class="arrow shown"></button>
 
 				<!-- Holds flashcards -->
-				<div id="container"></div>
-
-				<!-- FOR IE -->
-				<div id="clarification" style="display : none;"></div>
+				<section id="container"></section>
 
 				<!-- Finish message -->
-				<div id="finished" class="hidden">
+				<section id="finished" class="hidden">
 					<p>No cards remaining.</p>
-					<div id="icon-finish" class="icon"></div>
-				</div>
+					<button id="icon-finish" class="icon"></button>
+				</section>
 
-				<div aria-label="Restore cards." id="icon-restore" class="icon unselectable"></div>
-				<div aria-label="Rotate cards." id="icon-rotate" class="icon"></div>
-				<div aria-label="Shuffle cards." id="icon-shuffle" class="icon"></div>
+				<button aria-label="Restore cards." id="icon-restore" class="icon"></button>
+				<button aria-label="Rotate cards." id="icon-rotate" class="icon"></button>
+				<button aria-label="Shuffle cards." id="icon-shuffle" class="icon"></button>
 
-			</section>
+			</main>
 		</section>
 
 	</body>
 
 <!-- Flashcard Template -->
 <script type="text/template" id="t-flashcard"><div aria-label="flashcard" class="flashcard">
-	<div aria-label="back" class="back">
+	<section aria-label="back" class="back">
 		<div class="content"></div>
 		<div class="asset"></div>
-		<div aria-label="discard" class="remove-button">&#215;</div>
-	</div>
-	<div aria-label="front" class="front">
+		<button aria-label="discard" class="remove-button">&#215;</button>
+	</section>
+	<section aria-label="front" class="front">
 		<div class="content"></div>
 		<div class="asset"></div>
-		<div aria-label="discard" class="remove-button">&#215;</div>
-	</div>
+		<button aria-label="discard" class="remove-button">&#215;</button>
+	</section>
 </div></script>
 
 <!-- Templates for atari mode -->

--- a/src/player.html
+++ b/src/player.html
@@ -75,7 +75,8 @@
 				<p id="aria-updates"></p>
 			</section>
 
-			<button id="icon-help" class="icon" aria-label="Press H for help" title="Help"></button>
+			<button id="icon-help" class="icon" aria-label="Press H to open Keyboard Controls" title="Help"></button>
+			<button id="icon-close" class="icon" aria-label="Close Keyboard Controls" title="Help">x</button>
 
 			<section id="overlay" class="overlay">
 				<h2>Keyboard Controls</h2>
@@ -127,6 +128,8 @@
 					<circle cx="35" cy="25" r="7"></circle>
 				</svg>
 			</section>
+
+			<div onfocus="Namespace('Flashcards').Engine.hideOverlay(); document.querySelector('.flashcard').focus();" tabindex="0" id="hidden-tab-index"></div>
 
 			<main id="board">
 

--- a/src/player.html
+++ b/src/player.html
@@ -148,7 +148,7 @@
 
 				<!-- Finish message -->
 				<section id="finished" class="hidden">
-					<p id="finishedMssg">No cards remaining. Click to restore all cards.</p>
+					<p id="finishedMssg">No cards remaining.<br></br> Click to restore all cards.</p>
 					<button id="icon-finish" class="icon" aria-label="Restore cards." aria-describedby="finishedMssg" title="Restore cards"></button>
 				</section>
 

--- a/src/player.html
+++ b/src/player.html
@@ -71,6 +71,10 @@
 				<div></div>
 			</section>
 
+			<section role="region" aria-live="assertive" class="aria-live-region">
+				<p id="aria-updates"></p>
+			</section>
+
 			<button id="icon-help" class="icon" aria-label="Press H for help" title="Help"></button>
 
 			<section id="overlay" class="overlay">

--- a/src/player.html
+++ b/src/player.html
@@ -139,7 +139,6 @@
 
 				<button id="icon-right" class="arrow shown"  aria-label="Next card."></button>
 
-
 				<!-- Finish message -->
 				<section id="finished" class="hidden">
 					<p>No cards remaining.</p>
@@ -157,17 +156,16 @@
 
 <!-- Flashcard Template -->
 <script type="text/template" id="t-flashcard"><div aria-label="flashcard" class="flashcard" aria-hidden="true">
-		<section aria-label="back" class="back" aria-hidden="true">
-			<div class="content"></div>
-			<div class="asset"></div>
-			<button id="discard-front" aria-label="discard" class="remove-button" disabled="true" tabindex="-1">&#215;</button>
-		</section>
-		<section aria-label="front" class="front" aria-hidden="true">
-			<div class="content"></div>
-			<div class="asset"></div>
-			<button id="discard-back" aria-label="discard" class="remove-button" disabled="true" tabindex="-1">&#215;</button>
-		</section>
-	</div></script>
+	<section aria-label="back" class="back" aria-hidden="true">
+		<div class="content"></div>
+		<div class="asset"></div>
+	</section>
+	<section aria-label="front" class="front" aria-hidden="true">
+		<div class="content"></div>
+		<div class="asset"></div>
+	</section>
+	<button aria-label="discard" class="remove-button">&#215;</button>
+</div></script>
 
 <!-- Templates for atari mode -->
 <script type="text/template" id="t-arrow"><table border="0" cellpadding="0" cellspacing="0" class="arrow-table">

--- a/src/player.html
+++ b/src/player.html
@@ -157,17 +157,17 @@
 
 <!-- Flashcard Template -->
 <script type="text/template" id="t-flashcard"><div aria-label="flashcard" class="flashcard" aria-hidden="true">
-	<section aria-label="back" class="back" aria-hidden="true">
-		<div class="content"></div>
-		<div class="asset"></div>
-		<button id="discard-front" aria-label="discard" class="remove-button">&#215;</button>
-	</section>
-	<section aria-label="front" class="front" aria-hidden="false">
-		<div class="content"></div>
-		<div class="asset"></div>
-		<button id="discard-back" aria-label="discard" class="remove-button">&#215;</button>
-	</section>
-</div></script>
+		<section aria-label="back" class="back" aria-hidden="true">
+			<div class="content"></div>
+			<div class="asset"></div>
+			<button id="discard-front" aria-label="discard" class="remove-button" disabled="true" tabindex="-1">&#215;</button>
+		</section>
+		<section aria-label="front" class="front" aria-hidden="true">
+			<div class="content"></div>
+			<div class="asset"></div>
+			<button id="discard-back" aria-label="discard" class="remove-button" disabled="true" tabindex="-1">&#215;</button>
+		</section>
+	</div></script>
 
 <!-- Templates for atari mode -->
 <script type="text/template" id="t-arrow"><table border="0" cellpadding="0" cellspacing="0" class="arrow-table">

--- a/src/player.html
+++ b/src/player.html
@@ -71,61 +71,57 @@
 				<div></div>
 			</section>
 
-			<div tabindex="0" onfocus="document.getElementById('icon-help').focus()"></div>
-
 			<button id="icon-help" class="icon" aria-label="Press H for help" title="Help"></button>
 
 			<section id="overlay" class="overlay">
 				<h2>Keyboard Controls</h2>
-				<div class="arr box" id="left-arr" tabindex="0">previous card - A</div>
+				<div class="arr box" id="left-arr">previous card - A</div>
 				<svg class="arr" id="left-arr" aria-hidden="true">
 					<path d="M40 0 L20 65 Z"></path>
 					<circle cx="20" cy="65" r="7"></circle>
 				</svg>
 
-				<div class="arr box" id="right-arr" tabindex="0">next card - D</div>
+				<div class="arr box" id="right-arr">next card - D</div>
 				<svg class="arr" id="right-arr" aria-hidden="true">
 					<path d="M10 0 L30 65 Z"></path>
 					<circle cx="30" cy="65" r="7"></circle>
 				</svg>
 
-				<div id="flip" class="box" tabindex="0">flip card - F</div>
+				<div id="flip" class="box">flip card - F</div>
 				<svg class="arr" id="mid-arr" aria-hidden="true">
 					<path d="M25 0 L25 65 Z"></path>
 					<circle cx="25" cy="65" r="7"></circle>
 				</svg>
 
-				<div id="discard" class="box" tabindex="0">discard - X</div>
+				<div id="discard" class="box">discard - X</div>
 				<svg class="arr" id="right-arr-2" aria-hidden="true">
 					<path d="M0 25 L45 45 Z"></path>
 					<circle cx="40" cy="45" r="7"></circle>
 				</svg>
 
-				<div id="rotate" class="box" tabindex="0">rotate cards - R</div>
+				<div id="rotate" class="box">rotate cards - R</div>
 				<svg class="arr" id="bottom-mid-arr" aria-hidden="true">
 					<path d="M25 0 L25 45 Z"></path>
 					<circle cx="25" cy="45" r="7"></circle>
 				</svg>
 
-				<div id="shuffle" class="box" tabindex="0">shuffle cards - S</div>
+				<div id="shuffle" class="box">shuffle cards - S</div>
 				<svg class="arr" id="bottom-right-arr" aria-hidden="true">
 					<path d="M30 0 L10 25 Z"></path>
 					<circle cx="10" cy="25" r="7"></circle>
 				</svg>
 
-				<div id="restore-one" class="box" tabindex="0">restore last discard - W</div>
+				<div id="restore-one" class="box">restore last discard - W</div>
 				<svg class="arr" id="bottom-horiz-arr" aria-hidden="true">
 					<path d="M40 20 L25 20 Z"></path>
 					<circle cx="40" cy="20" r="7"></circle>
 				</svg>
 
-				<div id="restore-all" class="box" tabindex="0">restore deck - U</div>
+				<div id="restore-all" class="box">restore deck - U</div>
 				<svg class="arr" id="bottom-left-arr" aria-hidden="true">
 					<path d="M5 0 L35 25 Z"></path>
 					<circle cx="35" cy="25" r="7"></circle>
 				</svg>
-
-				<div id="dummy-card" tabindex="0" onfocus="document.getElementById('icon-help').focus()"></div>
 			</section>
 
 			<main id="board">

--- a/src/player.html
+++ b/src/player.html
@@ -144,6 +144,8 @@
 				<!-- Next card arrow -->
 				<button id="icon-right" class="arrow shown" aria-label="Next card" title="Next card"></button>
 
+				<section id="discardpile"></section>
+
 				<!-- Finish message -->
 				<section id="finished" class="hidden">
 					<p>No cards remaining.</p>

--- a/src/player.html
+++ b/src/player.html
@@ -59,7 +59,7 @@
 			</div>
 		</section>
 
-		<section id="game">
+		<section id="game" role="application">
 			<section id="atari-bg" aria-hidden="true">
 				<div></div>
 				<div></div>
@@ -70,6 +70,8 @@
 				<div></div>
 				<div></div>
 			</section>
+
+			<div tabindex="0" onfocus="document.getElementById('icon-help').focus()"></div>
 
 			<button id="icon-help" class="icon" aria-label="Press H for help"></button>
 
@@ -122,7 +124,7 @@
 					<circle cx="35" cy="25" r="7"></circle>
 				</svg>
 
-				<div id="dummy-card"></div>
+				<div id="dummy-card" tabindex="0" onfocus="document.getElementById('icon-help').focus()"></div>
 			</section>
 
 			<main id="board">
@@ -130,11 +132,13 @@
 				<h1 id="instance-title"></h1>
 
 				<!-- arrows -->
-				<button id="icon-left" class="arrow"></button>
-				<button id="icon-right" class="arrow shown"></button>
+				<button id="icon-left" class="arrow" aria-label="Previous card."></button>
 
 				<!-- Holds flashcards -->
 				<section id="container"></section>
+
+				<button id="icon-right" class="arrow shown"  aria-label="Next card."></button>
+
 
 				<!-- Finish message -->
 				<section id="finished" class="hidden">
@@ -152,16 +156,16 @@
 	</body>
 
 <!-- Flashcard Template -->
-<script type="text/template" id="t-flashcard"><div aria-label="flashcard" class="flashcard">
-	<section aria-label="back" class="back">
+<script type="text/template" id="t-flashcard"><div aria-label="flashcard" class="flashcard" aria-hidden="true">
+	<section aria-label="back" class="back" aria-hidden="true">
 		<div class="content"></div>
 		<div class="asset"></div>
-		<button aria-label="discard" class="remove-button">&#215;</button>
+		<button id="discard-front" aria-label="discard" class="remove-button">&#215;</button>
 	</section>
-	<section aria-label="front" class="front">
+	<section aria-label="front" class="front" aria-hidden="false">
 		<div class="content"></div>
 		<div class="asset"></div>
-		<button aria-label="discard" class="remove-button">&#215;</button>
+		<button id="discard-back" aria-label="discard" class="remove-button">&#215;</button>
 	</section>
 </div></script>
 

--- a/src/player.html
+++ b/src/player.html
@@ -44,7 +44,7 @@
 						<li>Shuffle the deck or flip all the cards and try to guess the other side.</li>
 					</ul>
 				</figure>
-				<button id="gotit" class="gotit" tabindex="0" onclick="Namespace('Flashcards').Engine.hideInstructions()">Got it!</button>
+				<button id="gotit" class="gotit" tabindex="0" onclick="Namespace('Flashcards').Engine.hideInstructions()" title="Click to continue">Got it!</button>
 			</div>
 		</section>
 
@@ -148,8 +148,8 @@
 
 				<!-- Finish message -->
 				<section id="finished" class="hidden">
-					<p>No cards remaining.</p>
-					<button id="icon-finish" class="icon"></button>
+					<p id="finishedMssg">No cards remaining. Click to restore all cards.</p>
+					<button id="icon-finish" class="icon" aria-label="Restore cards." aria-describedby="finishedMssg" title="Restore cards"></button>
 				</section>
 
 				<!-- Options for all flashcards -->

--- a/src/player.html
+++ b/src/player.html
@@ -73,9 +73,10 @@
 
 			<div tabindex="0" onfocus="document.getElementById('icon-help').focus()"></div>
 
-			<button id="icon-help" class="icon" aria-label="Press H for help"></button>
+			<button id="icon-help" class="icon" aria-label="Press H for help" title="Help"></button>
 
 			<section id="overlay" class="overlay">
+				<h2>Keyboard Controls</h2>
 				<div class="arr box" id="left-arr" tabindex="0">previous card - A</div>
 				<svg class="arr" id="left-arr" aria-hidden="true">
 					<path d="M40 0 L20 65 Z"></path>
@@ -96,8 +97,8 @@
 
 				<div id="discard" class="box" tabindex="0">discard - X</div>
 				<svg class="arr" id="right-arr-2" aria-hidden="true">
-					<path d="M30 0 L10 48 Z"></path>
-					<circle cx="10" cy="48" r="7"></circle>
+					<path d="M0 25 L45 45 Z"></path>
+					<circle cx="40" cy="45" r="7"></circle>
 				</svg>
 
 				<div id="rotate" class="box" tabindex="0">rotate cards - R</div>
@@ -131,13 +132,17 @@
 
 				<h1 id="instance-title"></h1>
 
-				<!-- arrows -->
-				<button id="icon-left" class="arrow" aria-label="Previous card."></button>
+				<!-- Previous card arrow -->
+				<button id="icon-left" class="arrow" aria-label="Previous card" title="Previous card"></button>
 
 				<!-- Holds flashcards -->
 				<section id="container"></section>
 
-				<button id="icon-right" class="arrow shown"  aria-label="Next card."></button>
+				<!-- Discard button -->
+				<button aria-label="Discard" class="remove-button" title="Discard">&#215;</button>
+
+				<!-- Next card arrow -->
+				<button id="icon-right" class="arrow shown" aria-label="Next card" title="Next card"></button>
 
 				<!-- Finish message -->
 				<section id="finished" class="hidden">
@@ -145,9 +150,10 @@
 					<button id="icon-finish" class="icon"></button>
 				</section>
 
-				<button aria-label="Restore cards." id="icon-restore" class="icon"></button>
-				<button aria-label="Rotate cards." id="icon-rotate" class="icon"></button>
-				<button aria-label="Shuffle cards." id="icon-shuffle" class="icon"></button>
+				<!-- Options for all flashcards -->
+				<button aria-label="Restore cards" id="icon-restore" class="icon" title="Restore cards"></button>
+				<button aria-label="Rotate cards" id="icon-rotate" class="icon" title="Rotate cards"></button>
+				<button aria-label="Shuffle cards" id="icon-shuffle" class="icon" title="Shuffle cards"></button>
 
 			</main>
 		</section>
@@ -156,15 +162,14 @@
 
 <!-- Flashcard Template -->
 <script type="text/template" id="t-flashcard"><div aria-label="flashcard" class="flashcard" aria-hidden="true">
-	<section aria-label="back" class="back" aria-hidden="true">
+	<section class="back" aria-hidden="true">
 		<div class="content"></div>
 		<div class="asset"></div>
 	</section>
-	<section aria-label="front" class="front" aria-hidden="true">
+	<section class="front" aria-hidden="true">
 		<div class="content"></div>
 		<div class="asset"></div>
 	</section>
-	<button aria-label="discard" class="remove-button">&#215;</button>
 </div></script>
 
 <!-- Templates for atari mode -->

--- a/src/player.html
+++ b/src/player.html
@@ -139,7 +139,7 @@
 				<section id="container"></section>
 
 				<!-- Discard button -->
-				<button aria-label="Discard" class="remove-button" title="Discard">&#215;</button>
+				<button aria-label="Discard" class="icon" id="icon-remove" title="Discard">&#215;</button>
 
 				<!-- Next card arrow -->
 				<button id="icon-right" class="arrow shown" aria-label="Next card" title="Next card"></button>

--- a/src/player.html
+++ b/src/player.html
@@ -163,7 +163,7 @@
 	</body>
 
 <!-- Flashcard Template -->
-<script type="text/template" id="t-flashcard"><div aria-label="flashcard" class="flashcard" aria-hidden="true">
+<script type="text/template" id="t-flashcard"><div aria-label="flashcard" class="flashcard" aria-hidden="true" role="region">
 	<section class="back" aria-hidden="true">
 		<div class="content"></div>
 		<div class="asset"></div>

--- a/src/player.html
+++ b/src/player.html
@@ -103,7 +103,7 @@
 					<circle cx="40" cy="45" r="7"></circle>
 				</svg>
 
-				<div id="rotate" class="box">rotate cards - R</div>
+				<div id="rotate" class="box">flip all cards - R</div>
 				<svg class="arr" id="bottom-mid-arr" aria-hidden="true">
 					<path d="M25 0 L25 45 Z"></path>
 					<circle cx="25" cy="45" r="7"></circle>
@@ -138,11 +138,11 @@
 				<!-- Holds flashcards -->
 				<section id="container"></section>
 
-				<!-- Discard button -->
-				<button aria-label="Discard" class="icon" id="icon-remove" title="Discard">&#215;</button>
-
 				<!-- Next card arrow -->
 				<button id="icon-right" class="arrow shown" aria-label="Next card" title="Next card"></button>
+
+				<!-- Discard button -->
+				<button aria-label="Discard" class="icon" id="icon-remove" title="Discard">&#215;</button>
 
 				<section id="discardpile"></section>
 
@@ -154,7 +154,7 @@
 
 				<!-- Options for all flashcards -->
 				<button aria-label="Restore cards" id="icon-restore" class="icon" title="Restore cards"></button>
-				<button aria-label="Rotate cards" id="icon-rotate" class="icon" title="Rotate cards"></button>
+				<button aria-label="Flip all cards" id="icon-rotate" class="icon" title="Flip all cards"></button>
 				<button aria-label="Shuffle cards" id="icon-shuffle" class="icon" title="Shuffle cards"></button>
 
 			</main>

--- a/src/player.scss
+++ b/src/player.scss
@@ -8,10 +8,21 @@
 	font-weight : normal;
 	font-style  : normal;
 }
+
+// Color palette.
+$a : #ADA4A4;
+$b : #1A1A1A;
+$c : #6B6263;
+$d : #543F3D;
+$e : #A45B5B;
+$f : #87735F;
+$g : #332a2a;
+
 #icon-help, #icon-shuffle,
 #icon-rotate, #icon-restore,
 #icon-finish, #icon-alert,
-#icon-left, #icon-right {
+#icon-left, #icon-right,
+#discard-front, #discard-back{
 	font-family            : 'icomoon';
 	font-style             : normal;
 	font-weight            : normal;
@@ -20,13 +31,10 @@
 	line-height            : 1;
 	-webkit-font-smoothing : antialiased;
 	border: none;
-	background: none;
+	background: rgba(0,0,0,0);
 
-	&:hover, &:focus {
-		color: rgb(54, 54, 54);
-	}
 }
-.icon {
+.icon, .arrow {
 	font-size     : 24px;
 	z-index       : 10;
 	position      : absolute;
@@ -35,7 +43,7 @@
 	border-radius : 100%;
 	height        : 24px;
 	width         : 24px;
-	color         : #222;
+	color         : $a;
 	padding       : 10px;
 
 	-webkit-transition : 100ms background-color, 500ms opacity;
@@ -43,7 +51,11 @@
 	    -ms-transition : 100ms background-color, 500ms opacity;
 	        transition : 100ms background-color, 500ms opacity;
 
-	&:hover, &.focused { background-color : rgba(255,255,255,0.6); }
+	&:hover, &:focus {
+		color: #FFF;
+		cursor: pointer;
+		outline: none;
+	}
 	&.faded-out    { opacity : 0; }
 	&.unselectable { opacity : 0.3; &:hover, &.focused {background-color : rgba(255,255,255,0) !important; }}
 	&#icon-restore { left : 40%; }
@@ -70,19 +82,11 @@
 #icon-right:before   { content : "\e000"; }
 #icon-alert          { content : "\e006"; }
 
-// Color palette.
-$a : #584B4B;
-$b : #44382A;
-$c : #6B6263;
-$d : #543F3D;
-$e : #A45B5B;
-$f : #87735F;
-
 
 body {
 	position         : absolute;
 	color            : #FFF;
-	background-color : $a !important;
+	background-color : $g !important;
 	padding          : 0;
 	margin           : 0;
 	width            : 800px;
@@ -100,11 +104,6 @@ body {
 	   -moz-user-select : none;
 	    -ms-user-select : none;
 			user-select : none;
-
-
-	*:focus {
-		outline: solid 2px #0093e7;
-	}
 
 	table { display: none; }
 	#game {
@@ -721,7 +720,6 @@ body {
 			top              : 50%;
 			position         : absolute;
 			margin-top       : -40px;
-			color            : rgba(0,0,0,0.4);
 			font-size        : 80px;
 			z-index          : 10;
 			padding			 : 0;
@@ -734,8 +732,8 @@ body {
 			   -moz-transition : 200ms all;
 			    -ms-transition : 200ms all;
 			        transition : 200ms all;
-			&#icon-left  { left  : 30px; }
-			&#icon-right { right : 30px; }
+			&#icon-left  { left  : 60px; }
+			&#icon-right { right : 90px; }
 			&.shown {
 				-webkit-transform : scale(1);
 				   -moz-transform : scale(1);
@@ -805,7 +803,7 @@ body {
 	right      : 0;
 	top        : 0;
 	bottom     : 0;
-	background : rgba(0,0,0,0.8);
+	background : $g;
 	display    : block;
 	color: #fff;
 	padding: 115px 50px;
@@ -888,9 +886,11 @@ body {
 		font-size: 20px;
 		cursor: pointer;
 		color: white;
+		border: none;
 
 		&:hover {
 			background: #73D15A;
+			cursor: pointer;
 		}
 	}
 }

--- a/src/player.scss
+++ b/src/player.scss
@@ -22,7 +22,7 @@ $g : #332a2a;
 #icon-rotate, #icon-restore,
 #icon-finish, #icon-alert,
 #icon-left, #icon-right,
-#discard-front, #discard-back{
+.discard {
 	font-family            : 'icomoon';
 	font-style             : normal;
 	font-weight            : normal;
@@ -539,12 +539,16 @@ body {
 				}
 				.remove-button {
 					position    : absolute;
-					right       : 0;
-					top         : 0;
-					height      : 30px;
-					width       : 30px;
+					right       : -15px;
+					top         : -15px;
+					height      : 35px;
+					width       : 35px;
 					line-height : 30px;
 					font-size   : 20px;
+					z-index		: 20;
+					border-radius: 50%;
+					color 		: $g;
+					background-color: $a;
 
 					-webkit-transition : 200ms all;
 					   -moz-transition : 200ms all;
@@ -552,8 +556,8 @@ body {
 					        transition : 200ms all;
 
 					&:hover {
-						color            : #FFF;
-						background-color : rgba(0,0,0,0.8);
+						color : $e;
+						cursor: pointer;
 
 						-webkit-transition : 200ms all;
 						   -moz-transition : 200ms all;

--- a/src/player.scss
+++ b/src/player.scss
@@ -726,30 +726,8 @@ body {
 				left     : auto;
 				bottom   : auto;
 				margin   : auto;
-				color    : #FFF;
-				&:hover { color : #222; }
-			}
-			.restart {
-				position      : absolute;
-				left          : 50%;
-				margin-left   : -21px;
-				fill          : #FFF;
-				stroke        : #FFF;
-				width         : 31px;
-				height        : 31px;
-				padding       : 5px;
-				border-radius : 100%;
-
-				-webkit-transition : 300ms all;
-				   -moz-transition : 300ms all;
-				    -ms-transition : 300ms all;
-				        transition : 300ms all;
-
-				&:hover {
-					background-color : rgba(255,255,255,0.6);
-					fill             : #222;
-					stroke           : #222;
-				}
+				color    : $a;
+				&:hover, &:focus { color : #fff; }
 			}
 		}
 		.arrow {

--- a/src/player.scss
+++ b/src/player.scss
@@ -15,6 +15,7 @@ $b : #1A1A1A;
 $c : #6B6263;
 $d : #543F3D;
 $e : #A45B5B;
+$e1 : #c47c7c;
 $f : #87735F;
 $g : #332a2a;
 
@@ -123,7 +124,12 @@ body {
 		-webkit-transition : 300ms all;
 		   -moz-transition : 300ms all;
 		    -ms-transition : 300ms all;
-		        transition : 300ms all;
+				transition : 300ms all;
+
+		h2 {
+			margin: 7.5px 0 0 50px;
+			color: $a;
+		}
 
 		&.shown { opacity : 1; }
 		.box {
@@ -131,6 +137,10 @@ body {
 			background-color : $e;
 			padding          : 5px 10px;
 			border-radius    : 5px;
+
+			&:focus {
+				background-color: $e1;
+			}
 
 			&.arr {
 				top : 168px;
@@ -145,8 +155,8 @@ body {
 				text-align  : center;
 			}
 			&#discard {
-				top   : 50px;
-				right : 100px;
+				bottom   : 175px;
+				right 	 : 130px;
 			}
 			&#rotate {
 				width       : 130px;
@@ -185,7 +195,7 @@ body {
 			}
 			&#left-arr         {              left  : 40px;  }
 			&#right-arr        {              right : 40px;  }
-			&#right-arr-2      { top : 77px;  right : 125px; }
+			&#right-arr-2      { bottom : 110px;  right : 80px; top: auto; }
 			&#mid-arr          { top : 100px; left  : 47%;   }
 			&#bottom-right-arr { top : 449px; right : 280px; }
 			&#bottom-mid-arr   { top : 410px; left  : 375px; }
@@ -271,6 +281,21 @@ body {
 						transition : all 700ms cubic-bezier(0.190, 1.000, 0.220, 1.000), color 100ms, z-index 0ms;
 
 				&.hidden { display: none; }
+
+				&:hover  { cursor: pointer; }
+				&:focus  .back, &:focus .front {
+					background-color: #fff;
+					outline: 1px solid blue;
+				}
+
+				&[class*="discarded"]:focus {
+					.front {
+						background-color: #fff;
+					}
+					.back {
+						background-color: #fff;
+					}
+				}
 
 				//////////////////////////////////////////
 				//           CARD STATES                //
@@ -537,41 +562,13 @@ body {
 					    -ms-transform : translate( 300%) rotateY(180deg);
 					        transform : translate( 300%) rotateY(180deg);
 				}
-				.remove-button {
-					position    : absolute;
-					right       : -15px;
-					top         : -15px;
-					height      : 35px;
-					width       : 35px;
-					line-height : 30px;
-					font-size   : 20px;
-					z-index		: 20;
-					border-radius: 50%;
-					color 		: $g;
-					background-color: $a;
-
-					-webkit-transition : 200ms all;
-					   -moz-transition : 200ms all;
-					    -ms-transition : 200ms all;
-					        transition : 200ms all;
-
-					&:hover {
-						color : $e;
-						cursor: pointer;
-
-						-webkit-transition : 200ms all;
-						   -moz-transition : 200ms all;
-						    -ms-transition : 200ms all;
-						        transition : 200ms all;
-					}
-				}
 				.front, .back {
 					position         : absolute;
 					top              : 0;
 					left             : 0;
 					height           : 100%;
 					width            : 100%;
-					background-color : #EEE;
+					background-color : $a;
 
 					-webkit-backface-visibility : hidden;
 					   -moz-backface-visibility : hidden;
@@ -669,6 +666,38 @@ body {
 					    -ms-transform : rotateY(-180deg);
 					        transform : rotateY(-180deg);
 				}
+			}
+		}
+
+		.remove-button {
+			position    : absolute;
+			right       : 50px;
+			top         : 65%;
+			height      : 50px;
+			width       : 50px;
+			line-height : 30px;
+			font-size   : 36px;
+			z-index		: 20;
+			border		: none;
+			border-radius: 50%;
+			color 		: $g;
+			background-color: $a;
+			padding		: 0px 0px 5px 0px;
+
+			-webkit-transition : 200ms all;
+			   -moz-transition : 200ms all;
+				-ms-transition : 200ms all;
+					transition : 200ms all;
+
+			&:hover, &:focus {
+				background-color : $e;
+				cursor: pointer;
+				outline: none;
+
+				-webkit-transition : 200ms all;
+				   -moz-transition : 200ms all;
+					-ms-transition : 200ms all;
+						transition : 200ms all;
 			}
 		}
 		#finished {

--- a/src/player.scss
+++ b/src/player.scss
@@ -13,13 +13,18 @@
 #icon-finish, #icon-alert,
 #icon-left, #icon-right {
 	font-family            : 'icomoon';
-	speak                  : none;
 	font-style             : normal;
 	font-weight            : normal;
 	font-variant           : normal;
 	text-transform         : none;
 	line-height            : 1;
 	-webkit-font-smoothing : antialiased;
+	border: none;
+	background: none;
+
+	&:hover, &:focus {
+		color: rgb(54, 54, 54);
+	}
 }
 .icon {
 	font-size     : 24px;
@@ -49,6 +54,13 @@
 
 .icon.unselectable:hover {background-color : rgba(255,255,255,0) !important;}
 
+.icon:before {
+	position: absolute;
+	left: 0;
+	right: 0;
+	top: 0;
+}
+
 #icon-help:before    { content : "\e005"; }
 #icon-shuffle:before { content : "\e004"; }
 #icon-rotate:before  { content : "\e003"; }
@@ -65,6 +77,7 @@ $c : #6B6263;
 $d : #543F3D;
 $e : #A45B5B;
 $f : #87735F;
+
 
 body {
 	position         : absolute;
@@ -86,7 +99,12 @@ body {
 	-webkit-user-select : none;
 	   -moz-user-select : none;
 	    -ms-user-select : none;
-	        user-select : none;
+			user-select : none;
+
+
+	*:focus {
+		outline: solid 2px #0093e7;
+	}
 
 	table { display: none; }
 	#game {
@@ -114,32 +132,7 @@ body {
 			background-color : $e;
 			padding          : 5px 10px;
 			border-radius    : 5px;
-		}
-		svg {
-			&.arr {
-				height   : 100px;
-				width    : 50px;
-				position : absolute;
-				top      : 195px;
-				path {
-					stroke       : $e;
-					stroke-width : 3;
-				}
-				circle {
-					fill         : $e;
-					stroke-width : 0;
-				}
-			}
-			&#left-arr         {              left  : 40px;  }
-			&#right-arr        {              right : 40px;  }
-			&#right-arr-2      { top : 77px;  right : 125px; }
-			&#mid-arr          { top : 100px; left  : 47%;   }
-			&#bottom-right-arr { top : 449px; right : 280px; }
-			&#bottom-mid-arr   { top : 430px; left  : 375px; }
-			&#bottom-horiz-arr { top : 466px; right : 75px;  }
-			&#bottom-left-arr  { top : 449px; left  : 285px; }
-		}
-		div {
+
 			&.arr {
 				top : 168px;
 				&#left-arr  { left  : 15px; }
@@ -169,12 +162,36 @@ body {
 			}
 			&#restore-one {
 				bottom : 20px;
-				right  : 100px;
+				right  : 50px;
 			}
 			&#restore-all {
 				bottom : 70px;
 				left   : 25%;
 			}
+		}
+		svg {
+			&.arr {
+				height   : 100px;
+				width    : 50px;
+				position : absolute;
+				top      : 195px;
+				path {
+					stroke       : $e;
+					stroke-width : 3;
+				}
+				circle {
+					fill         : $e;
+					stroke-width : 0;
+				}
+			}
+			&#left-arr         {              left  : 40px;  }
+			&#right-arr        {              right : 40px;  }
+			&#right-arr-2      { top : 77px;  right : 125px; }
+			&#mid-arr          { top : 100px; left  : 47%;   }
+			&#bottom-right-arr { top : 449px; right : 280px; }
+			&#bottom-mid-arr   { top : 410px; left  : 375px; }
+			&#bottom-horiz-arr { top : 466px; right : 25px;  }
+			&#bottom-left-arr  { top : 449px; left  : 285px; }
 		}
 		#dummy-card {
 			position : absolute;
@@ -210,6 +227,7 @@ body {
 		-moz-perspective : 800px; /* Mozilla, what were you thinking??? */
 		&.blurred {
 			opacity : 0.5;
+			z-index: -1;
 
 			-webkit-filter : blur(2px);
 			   -moz-filter : blur(2px);
@@ -699,8 +717,6 @@ body {
 			}
 		}
 		.arrow {
-			height           : 80px;
-			width            : 80px;
 			border-radius    : 100%;
 			top              : 50%;
 			position         : absolute;
@@ -708,6 +724,7 @@ body {
 			color            : rgba(0,0,0,0.4);
 			font-size        : 80px;
 			z-index          : 10;
+			padding			 : 0;
 
 			-webkit-transform : scale(0);
 			   -moz-transform : scale(0);

--- a/src/player.scss
+++ b/src/player.scss
@@ -930,4 +930,8 @@ body {
 		}
 	}
 }
-
+.aria-live-region {
+	position: absolute;
+	z-index: -100;
+	opacity: 0;
+}

--- a/src/player.scss
+++ b/src/player.scss
@@ -596,6 +596,11 @@ body {
 					width            : 100%;
 					background-color : $a;
 
+					display: flex;
+					flex-direction: column;
+					justify-content: center;
+					gap: 10px;
+
 					-webkit-backface-visibility : hidden;
 					   -moz-backface-visibility : hidden;
 					    -ms-backface-visibility : hidden;
@@ -607,8 +612,8 @@ body {
 					        transition : all 700ms cubic-bezier(0.190, 1.000, 0.220, 1.000);
 
 					.content {
-						height : inherit;
-						width  : inherit;
+						// height : inherit;
+						// width  : inherit;
 						overflow-y : auto;
 
 						-webkit-transform-style: preserve-3d;
@@ -640,7 +645,7 @@ body {
 						}
 					}
 					.asset {
-						margin-top : -280px;
+						// margin-top : -280px;
 
 						audio {
 							max-width : 100%;
@@ -662,7 +667,7 @@ body {
 								max-height : 200px;
 							}
 							&.mixed {
-								margin-top : 10%;
+								// margin-top : 10%;
 								max-height: 200px;
 							}
 						}

--- a/src/player.scss
+++ b/src/player.scss
@@ -22,7 +22,7 @@ $g : #332a2a;
 #icon-help, #icon-shuffle,
 #icon-rotate, #icon-restore,
 #icon-finish, #icon-alert,
-#icon-left, #icon-right,
+#icon-left, #icon-right, #icon-close
 .discard {
 	font-family            : 'icomoon';
 	font-style             : normal;
@@ -62,7 +62,7 @@ $g : #332a2a;
 	&.hidden	   { display: none; }
 	&#icon-restore { left : 40%; }
 	&#icon-rotate  { left : 50%; }
-	&#icon-help    { left : 35px; top : 10px; }
+	&#icon-help, &#icon-close    { left : 35px; top : 10px; }
 	&#icon-shuffle { left : 60%; }
 }
 
@@ -84,6 +84,30 @@ $g : #332a2a;
 #icon-right:before   { content : "\e000"; }
 #icon-alert          { content : "\e006"; }
 
+#icon-close {
+	line-height : 15px;
+	font-size   : 18px;
+	z-index		: 20;
+	border		: none;
+	color 		: $g;
+	padding		: 0 0 3px 0;
+
+	-webkit-transition : 200ms all;
+	-moz-transition : 200ms all;
+		-ms-transition : 200ms all;
+			transition : 200ms all;
+
+	&:hover, &:focus, &:active {
+		background-color : $a;
+		cursor: pointer;
+		outline: none;
+
+		-webkit-transition : 200ms all;
+		-moz-transition : 200ms all;
+			-ms-transition : 200ms all;
+				transition : 200ms all;
+	}
+}
 
 body {
 	position         : absolute;
@@ -115,6 +139,7 @@ body {
 	#fake-loading-screen {
 		display : none;
 	}
+
 	.overlay {
 		opacity  : 0;
 		position : absolute;
@@ -686,7 +711,6 @@ body {
 			border-radius: 50%;
 			color 		: $g;
 			background-color: $a;
-			padding		: 0px 0px 5px 0px;
 
 			-webkit-transition : 200ms all;
 			   -moz-transition : 200ms all;

--- a/src/player.scss
+++ b/src/player.scss
@@ -148,7 +148,7 @@ body {
 			&#flip {
 				top         : 14%;
 				left        : 50%;
-				width       : 70px;
+				width       : 100px;
 				margin-left : -45px;
 				text-align  : center;
 			}
@@ -157,8 +157,8 @@ body {
 				right : 100px;
 			}
 			&#rotate {
-				width       : 100px;
-				bottom      : 75px;
+				width       : 130px;
+				bottom      : 110px;
 				left        : 50%;
 				margin-left : -60px;
 				text-align  : center;
@@ -169,7 +169,7 @@ body {
 			}
 			&#restore-one {
 				bottom : 20px;
-				right  : 120px;
+				right  : 100px;
 			}
 			&#restore-all {
 				bottom : 70px;

--- a/src/player.scss
+++ b/src/player.scss
@@ -59,6 +59,7 @@ $g : #332a2a;
 	}
 	&.faded-out    { opacity : 0; }
 	&.unselectable { opacity : 0.3; &:hover, &.focused {background-color : rgba(255,255,255,0) !important; }}
+	&.hidden	   { display: none; }
 	&#icon-restore { left : 40%; }
 	&#icon-rotate  { left : 50%; }
 	&#icon-help    { left : 35px; top : 10px; }

--- a/src/player.scss
+++ b/src/player.scss
@@ -247,14 +247,14 @@ body {
 			margin-top : 3%;
 			font-size  : 35px;
 		}
-		#container {
+		#container, #discardpile {
 			position : absolute;
 			height   : 300px;
 			width    : 500px;
 			top      : 50%;
 			left     : 50%;
 			margin   : -150px 0 0 -250px;
-			z-index  : 1;
+			z-index  : 2;
 			-moz-transform-style : preserve-3d; /* NOOOOO */
 			&.hidden { z-index: -1; }
 			#restore-single {
@@ -666,6 +666,9 @@ body {
 					    -ms-transform : rotateY(-180deg);
 					        transform : rotateY(-180deg);
 				}
+			}
+			&#discardpile {
+				z-index: 1;
 			}
 		}
 

--- a/src/player.scss
+++ b/src/player.scss
@@ -669,7 +669,7 @@ body {
 			}
 		}
 
-		.remove-button {
+		#icon-remove {
 			position    : absolute;
 			right       : 50px;
 			top         : 65%;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4565,7 +4565,7 @@ next-tick@^1.0.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
-"ngmodal@github:ucfcdl/ngModal#v1.2.2":
+ngmodal@ucfcdl/ngModal#v1.2.2:
   version "1.2.2"
   resolved "https://codeload.github.com/ucfcdl/ngModal/tar.gz/6abad982bdb8f258ffcdc20316a907c2292399d2"
 


### PR DESCRIPTION
This addresses keyboard navigation and screenreader accessibility issues in the Player. 

Problem | Action | Completed
-- | -- | --
Tutorial modal doesn't have initial focus. | Add role="alertdialog", aria-labelledby, aria-describedby and somehow change focus to the modal, possibly by moving it to the top of the DOM and hiding the other content until "Got It" is pressed. | Yes
Button functionality strictly limited to mouse interactions. | Appears to be using the library Hammer for button events. Event "tap" is not fired when clicked.  Add ``onClick`` and keyboard events to buttons. | Yes
Can use tab navigation to see flashcards not in frame, including the back of cards when front is being shown. | Remove flashcards from tab order, add aria-hidden to opposite side of card, add aria-label to flashcards  | Yes
Similar to the problem above. Flashcards require multiple key presses to navigate and read before proceeding in VoiceOver | Either minimize the number of keypresses or remove them altogether by assigning an aria-label to the flashcard parent element that reads out the card's contents. | Former option
Using ``<div>``'s for buttons and other HTML semantic elements. | Use HTML semantics and aria-roles. | Yes
Arrow keys are being to move between flash cards, but this key is used by VoiceOver for navigating. | Make left and right arrow buttons easily navigable. New/additional key bindings: S (discard), A (left card), D (right card), W (un-discard) | Yes
Images don't have descriptions | Add the alt attribute to images | Yes
Instructions rely on visual aids. | Make instructions universal. | Partial
Color contrast ratio is 1.61:1 | Make color contrast ratio 4.5:1 to meet WCAG AA for Normal Text. | Yes
Discard pile's tab index is the same placement as it was in the flashcards. This could pose an issue with large numbers of flashcards. | Remove and add the flashcard to a separate DOM element. Perform the reverse for undiscard. | Yes

(**Update**: See below!) One outstanding issue that I'm still struggling with is that flashcards are being treated as "groups". Sometimes the user must navigate backwards to read the card's contents (e.g. when they click the Next Card arrow). I'm not sure if this is something that's normal or that should be replaced with an overarching aria-label on the parent flashcard.

### **Update**
There are two versions for testing. The latest commit makes flashcards a single aria label. To test the other version run ``git checkout 18af1c51f9c33a777d8a60d2ae86de2252b6347d``.
